### PR TITLE
[CPU][SVE] Update how matmul tile sizes are calculated

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -2,10 +2,10 @@
 #   * main-dist-linux (CMake 'install')
 #   * py-compiler-pkg (`iree-compiler` Python package)
 #     * Linux, macOS, Windows
-#     * All supported Python versions (e.g. 3.8, 3.9, 3.10, 3.11)
+#     * All supported Python versions (e.g. 3.9, 3.10, 3.11)
 #   * py-runtime-pkg (`iree-runtime` Python package)
 #     * Linux, macOS, Windows
-#     * All supported Python versions (e.g. 3.8, 3.9, 3.10, 3.11)
+#     * All supported Python versions (e.g. 3.9, 3.10, 3.11)
 #   * py-tf-compiler-tools-pkg (`iree-tools-[tf, tflite]`, pure Python packages)
 
 name: Build Release Packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -548,7 +548,7 @@ jobs:
           output_dir: "${{ github.workspace }}/bindist"
           # Note when upgrading: Build just one Python version synced to our
           # minimum.
-          override_python_versions: cp38-cp38
+          override_python_versions: cp39-cp39
         run: |
           ./build_tools/python_deploy/build_linux_packages.sh
       # Note that it is just a trade-off decision to have this serialized
@@ -562,7 +562,7 @@ jobs:
           output_dir: "${{ github.workspace }}/bindist"
           # Note when upgrading: Build just one Python version synced to our
           # minimum.
-          override_python_versions: cp38-cp38
+          override_python_versions: cp39-cp39
         run: |
           ./build_tools/python_deploy/build_linux_packages.sh
 

--- a/.github/workflows/validate_and_publish_release.yml
+++ b/.github/workflows/validate_and_publish_release.yml
@@ -37,7 +37,7 @@ jobs:
         id: set_up_python
         uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435  # v4.5.0
         with:
-          python-version: "3.8"
+          python-version: "3.9"
       - name: Install python packages
         id: install_python_packages
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -630,15 +630,15 @@ if(IREE_BUILD_PYTHON_BINDINGS)
   # "Bootstrapping" by first looking for the optional Development component
   # seems to be robust generally.
   # See: https://reviews.llvm.org/D118148
-  # If building Python packages, we have a hard requirement on 3.8+.
-  find_package(Python3 3.8 COMPONENTS Interpreter Development NumPy)
-  find_package(Python3 3.8 COMPONENTS Interpreter Development.Module NumPy REQUIRED)
+  # If building Python packages, we have a hard requirement on 3.9+.
+  find_package(Python3 3.9 COMPONENTS Interpreter Development NumPy)
+  find_package(Python3 3.9 COMPONENTS Interpreter Development.Module NumPy REQUIRED)
   # Some parts of the build use FindPython instead of FindPython3. Why? No
   # one knows, but they are different. So make sure to bootstrap this one too.
   # Not doing this here risks them diverging, which on multi-Python systems,
   # can be troublesome. Note that nanobind requires FindPython.
   set(Python_EXECUTABLE "${Python3_EXECUTABLE}")
-  find_package(Python 3.8 COMPONENTS Interpreter Development.Module NumPy REQUIRED)
+  find_package(Python 3.9 COMPONENTS Interpreter Development.Module NumPy REQUIRED)
 elseif(IREE_BUILD_COMPILER OR IREE_BUILD_TESTS)
   find_package(Python3 COMPONENTS Interpreter REQUIRED)
   set(Python_EXECUTABLE "${Python3_EXECUTABLE}")

--- a/build_tools/pkgci/build_linux_packages.sh
+++ b/build_tools/pkgci/build_linux_packages.sh
@@ -16,14 +16,14 @@
 #   ./build_tools/python_deploy/build_linux_packages.sh
 #
 # Build specific Python versions and packages to custom directory:
-#   override_python_versions="cp38-cp38 cp39-cp39" \
+#   override_python_versions="cp39-cp39 cp310-cp310" \
 #   packages="iree-runtime" \
 #   output_dir="/tmp/wheelhouse" \
 #   ./build_tools/python_deploy/build_linux_packages.sh
 #
 # Valid Python versions match a subdirectory under /opt/python in the docker
 # image. Typically:
-#   cp38-cp38 cp39-cp39 cp310-cp310
+#   cp39-cp39 cp310-cp310
 #
 # Valid packages:
 #   iree-runtime

--- a/build_tools/python_deploy/build_linux_packages.sh
+++ b/build_tools/python_deploy/build_linux_packages.sh
@@ -16,14 +16,14 @@
 #   ./build_tools/python_deploy/build_linux_packages.sh
 #
 # Build specific Python versions and packages to custom directory:
-#   override_python_versions="cp38-cp38 cp39-cp39" \
+#   override_python_versions="cp39-cp39 cp310-310" \
 #   packages="iree-runtime" \
 #   output_dir="/tmp/wheelhouse" \
 #   ./build_tools/python_deploy/build_linux_packages.sh
 #
 # Valid Python versions match a subdirectory under /opt/python in the docker
 # image. Typically:
-#   cp38-cp38 cp39-cp39 cp310-cp310
+#   cp39-cp39 cp310-cp310
 #
 # Valid packages:
 #   iree-runtime
@@ -65,7 +65,7 @@ this_dir="$(cd $(dirname $0) && pwd)"
 script_name="$(basename $0)"
 repo_root=$(cd "${this_dir}" && find_git_dir_parent)
 manylinux_docker_image="${manylinux_docker_image:-$(uname -m | awk '{print ($1 == "aarch64") ? "quay.io/pypa/manylinux_2_28_aarch64" : "gcr.io/iree-oss/manylinux2014_x86_64-release@sha256:e83893d35be4ce3558c989e9d5ccc4ff88d058bc3e74a83181059cc76e2cf1f8" }')}"
-python_versions="${override_python_versions:-cp38-cp38 cp39-cp39 cp310-cp310 cp311-cp311}"
+python_versions="${override_python_versions:-cp39-cp39 cp310-cp310 cp311-cp311}"
 output_dir="${output_dir:-${this_dir}/wheelhouse}"
 packages="${packages:-iree-runtime iree-compiler}"
 package_suffix="${package_suffix:-}"

--- a/compiler/bindings/python/iree/compiler/tools/tf.py
+++ b/compiler/bindings/python/iree/compiler/tools/tf.py
@@ -129,11 +129,11 @@ def compile_saved_model(saved_model_dir: str, **kwargs):
         elif options.save_temp_iree_input:
             # Saving the file, use tfs.
             tf_iree_input = tfs.alloc_optional(
-                "tf-iree-input.mlir", export_as=options.save_temp_iree_input
+                "tf-iree-input.mlirbc", export_as=options.save_temp_iree_input
             )
         else:
             # Not saving the file, so generate a loose temp file without tfs.
-            tf_iree_input = os.path.join(tmpdir, "tf-iree-input.mlir")
+            tf_iree_input = os.path.join(tmpdir, "tf-iree-input.mlirbc")
 
         __main__.import_saved_model(
             output_path=tf_iree_input,
@@ -146,7 +146,7 @@ def compile_saved_model(saved_model_dir: str, **kwargs):
         if options.import_only:
             if options.output_file:
                 return None
-            with open(tf_iree_input, "r") as f:
+            with open(tf_iree_input, "rb") as f:
                 return f.read()
 
         # Run IREE compilation pipeline

--- a/compiler/setup.py
+++ b/compiler/setup.py
@@ -423,7 +423,6 @@ setup(
         "Development Status :: 3 - Alpha",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.h
@@ -108,8 +108,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createEmulateNarrowTypePass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createEraseDeadAllocAndStoresPass();
 
-std::unique_ptr<OperationPass<func::FuncOp>>
-createEraseHALDescriptorTypeFromMemRefPass();
+std::unique_ptr<Pass> createEraseHALDescriptorTypeFromMemRefPass();
 
 // Extract address computations into their own separate instructions.
 std::unique_ptr<Pass> createExtractAddressComputationPass();
@@ -247,7 +246,7 @@ std::unique_ptr<OperationPass<func::FuncOp>> createTypePropagationPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createVectorizePadPass();
 
 /// Erases #hal.descriptor_type as MemRef memory space.
-LogicalResult eraseHALDescriptorTypeFromMemRef(func::FuncOp funcOp);
+LogicalResult eraseHALDescriptorTypeFromMemRef(Operation *op);
 
 /// Populates patterns with patterns to concretize tensor.pad op's result
 /// shape. `numWorkgroups`, if not empty, will be used as bounds for simplifying

--- a/compiler/src/iree/compiler/Codegen/Common/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Common/Passes.td
@@ -177,8 +177,8 @@ def EraseDeadAllocAndStores :
       "mlir::iree_compiler::createEraseDeadAllocAndStoresPass()";
 }
 
-def EraseHALDescriptorTypeFromMemRef :
-    Pass<"iree-codegen-erase-hal-descriptor-type-from-memref", "func::FuncOp"> {
+def EraseHALDescriptorTypeFromMemRef
+    : Pass<"iree-codegen-erase-hal-descriptor-type-from-memref"> {
   let summary = "Erase #hal.descriptor_type from MemRef memory space";
   let constructor =
       "mlir::iree_compiler::createEraseHALDescriptorTypeFromMemRefPass()";

--- a/compiler/src/iree/compiler/Codegen/Common/test/erase_hal_descriptor_type.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/erase_hal_descriptor_type.mlir
@@ -41,3 +41,20 @@ func.func @shared_memory_address_space() {
   "dialect.memref_consumer"(%3) : (memref<?x8xf32, 3>) -> ()
   return
 }
+
+// -----
+
+// CHECK-LABEL: func.func @multi_block()
+func.func @multi_block() {
+  // CHECK:   %[[P:.+]] = "dialect.memref_producer"() : () -> memref<?x8xf32>
+  // CHECK:   cf.br ^[[B:bb.+]](%[[P]] : memref<?x8xf32>)
+  // CHECK: ^[[B]](%[[A:.+]]: memref<?x8xf32>):
+  // CHECK:   "dialect.memref_consumer"(%[[A]]) : (memref<?x8xf32>) -> ()
+  %0 = "dialect.memref_producer"() : () -> (memref<?x8xf32, #hal.descriptor_type<uniform_buffer>>)
+  cf.br ^bb2(%0: memref<?x8xf32, #hal.descriptor_type<uniform_buffer>>)
+^bb2(%1 : memref<?x8xf32, #hal.descriptor_type<uniform_buffer>>):
+  "dialect.memref_consumer"(%1) : (memref<?x8xf32, #hal.descriptor_type<uniform_buffer>>) -> ()
+  return
+}
+
+

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1236,6 +1236,12 @@ getDefaultDistributionTileSizes(TilingInterface op) {
 }
 
 static bool isPackMatmulLHS(tensor::PackOp op) {
+  // linalg.batch_matmul LHS shape
+  if (op.getSourceRank() == 3 && op.getInnerDimsPos().size() == 2 &&
+      op.getInnerDimsPos()[0] == 1 && op.getInnerDimsPos()[1] == 2) {
+    return true;
+  }
+  // linalg.matmul LHS shape
   return op.getSourceRank() == 2 && op.getInnerDimsPos().size() == 2 &&
          op.getInnerDimsPos()[0] == 0 && op.getInnerDimsPos()[1] == 1;
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -686,8 +686,7 @@ void addTransformDialectPasses(OpPassManager &passManager) {
 static void addLowerToLLVMPasses(OpPassManager &passManager) {
   // TODO: Remove the following pass and plumb support for #hal.descriptor_type
   // memory space through the stack.
-  passManager.addNestedPass<func::FuncOp>(
-      createEraseHALDescriptorTypeFromMemRefPass());
+  passManager.addPass(createEraseHALDescriptorTypeFromMemRefPass());
 
   // Lower `ukernel.*` ops to function calls
   passManager.addPass(createLowerUKernelOpsToCallsPass());
@@ -774,8 +773,7 @@ void buildLLVMCPUCodegenPassPipeline(OpPassManager &passManager) {
         createCPUMaterializeEncodingPass());
     // TODO: Remove the following pass the plumb support for
     // #hal.descriptor_type memory space through the stack.
-    modulePassManager.addNestedPass<func::FuncOp>(
-        createEraseHALDescriptorTypeFromMemRefPass());
+    modulePassManager.addPass(createEraseHALDescriptorTypeFromMemRefPass());
   }
 
   passManager.addPass(createLLVMCPULowerExecutableTargetPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -607,6 +607,8 @@ void addMmt4dTilingExpertPassPipeline(OpPassManager &passManager,
   OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
 
   if (enableMicrokernels) {
+    nestedModulePM.addNestedPass<func::FuncOp>(
+        createDecomposeBatchMmt4DOpsPass());
     nestedModulePM.addPass(
         createLLVMCPULowerToUKernelsPass(clSkipIntermediateRoundings));
   } else {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_aarch64_launch_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_aarch64_launch_configuration.mlir
@@ -57,6 +57,60 @@ hal.executable private @matmul_tensors  {
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
     #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>,
+    #hal.descriptor_set.binding<3, storage_buffer>
+  ]>
+]>
+hal.executable private @matmul_tensors_sve  {
+  hal.executable.variant @llvm, target = <"llvm-cpu", "embedded-elf-arm_64", {
+    data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+    cpu_features = "+sve",
+    native_vector_size = 16 : index,
+    target_triple = "aarch64-none-elf"
+  }> {
+    hal.executable.export @matmul_tensors layout(#pipeline_layout)
+    builtin.module {
+      func.func @matmul_tensors() {
+        %c0 = arith.constant 0 : index
+        %c1 = arith.constant 1 : index
+        %M = hal.interface.constant.load[0] : index
+        %N = hal.interface.constant.load[1] : index
+        %K = hal.interface.constant.load[2] : index
+        %lhs_binding = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
+            : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%M, %K}
+        %rhs_binding = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer)
+            : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%K, %N}
+        %init_binding = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer)
+            : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%M, %N}
+        %result_binding = hal.interface.binding.subspan set(0) binding(3) type(storage_buffer)
+            : !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>{%M, %N}
+              %lhs = flow.dispatch.tensor.load %lhs_binding, offsets = [0, 0], sizes = [%M, %K], strides = [1, 1]
+            : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%M, %K} -> tensor<?x?xf32>
+        %rhs = flow.dispatch.tensor.load %rhs_binding, offsets = [0, 0], sizes = [%K, %N], strides = [1, 1]
+            : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%K, %N} -> tensor<?x?xf32>
+        %init = flow.dispatch.tensor.load %init_binding, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
+            : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%M, %N} -> tensor<?x?xf32>
+        %gemm = linalg.matmul ins(%lhs, %rhs : tensor<?x?xf32>, tensor<?x?xf32>) outs(%init : tensor<?x?xf32>) -> tensor<?x?xf32>
+        flow.dispatch.tensor.store %gemm, %result_binding, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
+            : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>{%M, %N}
+        return
+      }
+    }
+  }
+}
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64, 0], [20, 4, 0], [0, 0, 64], [0, 0, 0]]>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
+//      CHECK: hal.executable.export public @matmul_tensors
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
+//      CHECK: linalg.matmul
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
     #hal.descriptor_set.binding<2, storage_buffer>
   ]>
 ]>

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_aarch64_launch_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_aarch64_launch_configuration.mlir
@@ -98,7 +98,7 @@ hal.executable private @matmul_tensors_sve  {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64, 0], [20, 4, 0], [0, 0, 64], [0, 0, 0]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[128, 128, 0], [8, 32, 0], [0, 0, 16], [0, 0, 0]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable.export public @matmul_tensors
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/vector_masking.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/vector_masking.mlir
@@ -257,10 +257,67 @@ hal.executable private @preset_config_generic_add  {
   }
 }
 
-// Masking should not happen on aarch64 is there is no SVE support.
+// Masking should not happen on aarch64 if there is no SVE support.
 
 // CHECK-LABEL: func.func @mask_dynamic_generic_add
 //   CHECK-NOT:   vector.maskedload
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>,
+    #hal.descriptor_set.binding<3, storage_buffer>
+  ]>
+]>
+hal.executable private @preset_config_matmul  {
+  hal.executable.variant @llvm, target = <"llvm-cpu", "embedded-elf-arm_64", {
+    data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+    cpu_features = "+sve",
+    native_vector_size = 16 : index,
+    target_triple = "aarch64-none-elf"
+  }> {
+    hal.executable.export @mask_matmul_sve layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @mask_matmul_sve() {
+        %c0 = arith.constant 0 : index
+        %c1 = arith.constant 1 : index
+        %M = hal.interface.constant.load[0] : index
+        %N = hal.interface.constant.load[1] : index
+        %K = hal.interface.constant.load[2] : index
+        %lhs_binding = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
+            : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%M, %K}
+        %rhs_binding = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer)
+            : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%K, %N}
+        %init_binding = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer)
+            : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%M, %N}
+        %result_binding = hal.interface.binding.subspan set(0) binding(3) type(storage_buffer)
+            : !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>{%M, %N}
+              %lhs = flow.dispatch.tensor.load %lhs_binding, offsets = [0, 0], sizes = [%M, %K], strides = [1, 1]
+            : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%M, %K} -> tensor<?x?xf32>
+        %rhs = flow.dispatch.tensor.load %rhs_binding, offsets = [0, 0], sizes = [%K, %N], strides = [1, 1]
+            : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%K, %N} -> tensor<?x?xf32>
+        %init = flow.dispatch.tensor.load %init_binding, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
+            : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%M, %N} -> tensor<?x?xf32>
+        %gemm = linalg.matmul ins(%lhs, %rhs : tensor<?x?xf32>, tensor<?x?xf32>) outs(%init : tensor<?x?xf32>) -> tensor<?x?xf32>
+        flow.dispatch.tensor.store %gemm, %result_binding, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
+            : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>{%M, %N}
+        return
+      }
+    }
+  }
+}
+
+// Masking is applied to the matmul on aarch64 when SVE is enabled.
+
+// CHECK-LABEL: func.func @mask_matmul_sve
+// CHECK:   vector.maskedload
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -487,7 +487,7 @@ static void addLowerAndOptimzeAddressComputation(OpPassManager &pm) {
 static void addLowerToLLVMGPUPasses(OpPassManager &pm, bool useROCM) {
   // TODO: Remove the following pass the plumb support for #hal.descriptor_type
   // memory space through the stack.
-  pm.addNestedPass<func::FuncOp>(createEraseHALDescriptorTypeFromMemRefPass());
+  pm.addPass(createEraseHALDescriptorTypeFromMemRefPass());
 
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FuseDequantizationMatmul.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FuseDequantizationMatmul.cpp
@@ -64,15 +64,6 @@ static LogicalResult isGroupedContractionOp(linalg::GenericOp genericOp) {
     return failure();
   if (genericOp.getNumReductionLoops() != 2)
     return failure();
-  if (!llvm::cast<ShapedType>(genericOp.getInputs()[0].getType())
-           .hasStaticShape() ||
-      !llvm::cast<ShapedType>(genericOp.getInputs()[0].getType())
-           .hasStaticShape() ||
-      !llvm::cast<ShapedType>(genericOp.getInputs()[0].getType())
-           .hasStaticShape()) {
-    // Codegen can't handle the dynamic case yet.
-    return failure();
-  }
   return success();
 }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -170,6 +170,7 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
       // compute op into the dispatch region, so that we can run additional
       // transformations afterwards with a simple region and without bothering
       // producers.
+      .addPass(IREE::Flow::createTopLevelSCFToCFGPass)
       .addPass([&]() {
         return createFormDispatchRegionsPass(FormDispatchRegionsOptions{
             clEnableFuseMultiUse, clDispatchGenerateWorkloadRegion,

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/set_encoding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/set_encoding.mlir
@@ -261,6 +261,348 @@ func.func @matmul_bf16bf16bf16(%arg0 : tensor<100x250xbf16>, %arg1 : tensor<250x
 
 // -----
 
+func.func @batch_matmul_f32f32f32(%arg0 : tensor<64x100x250xf32>, %arg1 : tensor<64x250x500xf32>,
+    %arg2 : tensor<64x100x500xf32>) -> tensor<64x100x500xf32> {
+  %0 = linalg.batch_matmul ins(%arg0, %arg1 : tensor<64x100x250xf32>, tensor<64x250x500xf32>)
+      outs(%arg2 : tensor<64x100x500xf32>) -> tensor<64x100x500xf32>
+  return %0 : tensor<64x100x500xf32>
+}
+//      CHECK: #[[MAP:.+]] = affine_map<()[s0, s1] -> (-s1 + (s1 ceildiv s0) * s0)>
+//      CHECK: func @batch_matmul_f32f32f32(
+// CHECK-SAME:     %[[ARG0:.+]]: tensor<64x100x250xf32>
+// CHECK-SAME:     %[[ARG1:.+]]: tensor<64x250x500xf32>
+// CHECK-SAME:     %[[ARG2:.+]]: tensor<64x100x500xf32>
+//  CHECK-DAG:     %[[C64:.+]] = arith.constant 64 : index
+//  CHECK-DAG:     %[[C100:.+]] = arith.constant 100 : index
+//  CHECK-DAG:     %[[C250:.+]] = arith.constant 250 : index
+//  CHECK-DAG:     %[[C500:.+]] = arith.constant 500 : index
+//      CHECK:   %[[LHS_TILE_SIZE:.+]]:3 = iree_linalg_ext.upper_bound_tile_size tensor<64x100x250xf32, #iree_linalg_ext.encoding<user = BATCH_MATMUL_F32F32F32, role = LHS>> -> index, index, index
+//      CHECK:   %[[LHS_PADDING_SIZE0:.+]] = affine.apply #[[MAP]]()[%[[LHS_TILE_SIZE]]#0, %[[C64]]]
+//      CHECK:   %[[LHS_PADDING_SIZE1:.+]] = affine.apply #[[MAP]]()[%[[LHS_TILE_SIZE]]#1, %[[C100]]]
+//      CHECK:   %[[LHS_PADDING_SIZE2:.+]] = affine.apply #[[MAP]]()[%[[LHS_TILE_SIZE]]#2, %[[C250]]]
+//      CHECK:   %[[LHS_PAD:.+]] = tensor.pad %[[ARG0]] low[0, 0, 0] high[%[[LHS_PADDING_SIZE0]], %[[LHS_PADDING_SIZE1]], %[[LHS_PADDING_SIZE2]]]
+//      CHECK:       tensor<64x100x250xf32> to tensor<?x?x?xf32>
+//      CHECK:   %[[LHS:.+]] = iree_linalg_ext.set_encoding %[[LHS_PAD]]
+// CHECK-SAME:       tensor<?x?x?xf32, #iree_linalg_ext.encoding<user = BATCH_MATMUL_F32F32F32, role = LHS, original_type = tensor<64x100x250xf32>>>
+//      CHECK:   %[[RHS_TILE_SIZE:.+]]:3 = iree_linalg_ext.upper_bound_tile_size tensor<64x250x500xf32, #iree_linalg_ext.encoding<user = BATCH_MATMUL_F32F32F32, role = RHS>> -> index, index, index
+//      CHECK:   %[[RHS_PADDING_SIZE0:.+]] = affine.apply #[[MAP]]()[%[[RHS_TILE_SIZE]]#0, %[[C64]]]
+//      CHECK:   %[[RHS_PADDING_SIZE1:.+]] = affine.apply #[[MAP]]()[%[[RHS_TILE_SIZE]]#1, %[[C250]]]
+//      CHECK:   %[[RHS_PADDING_SIZE2:.+]] = affine.apply #[[MAP]]()[%[[RHS_TILE_SIZE]]#2, %[[C500]]]
+//      CHECK:   %[[RHS_PAD:.+]] = tensor.pad %[[ARG1]] low[0, 0, 0] high[%[[RHS_PADDING_SIZE0]], %[[RHS_PADDING_SIZE1]], %[[RHS_PADDING_SIZE2]]]
+//      CHECK:       tensor<64x250x500xf32> to tensor<?x?x?xf32>
+//      CHECK:   %[[RHS:.+]] = iree_linalg_ext.set_encoding %[[RHS_PAD]]
+// CHECK-SAME:       tensor<?x?x?xf32, #iree_linalg_ext.encoding<user = BATCH_MATMUL_F32F32F32, role = RHS, original_type = tensor<64x250x500xf32>>>
+//      CHECK:   %[[OUTS_TILE_SIZE:.+]]:3 = iree_linalg_ext.upper_bound_tile_size tensor<64x100x500xf32, #iree_linalg_ext.encoding<user = BATCH_MATMUL_F32F32F32, role = RESULT>> -> index, index, index
+//      CHECK:   %[[OUTS_PADDING_SIZE0:.+]] = affine.apply #[[MAP]]()[%[[OUTS_TILE_SIZE]]#0, %[[C64]]]
+//      CHECK:   %[[OUTS_PADDING_SIZE1:.+]] = affine.apply #[[MAP]]()[%[[OUTS_TILE_SIZE]]#1, %[[C100]]]
+//      CHECK:   %[[OUTS_PADDING_SIZE2:.+]] = affine.apply #[[MAP]]()[%[[OUTS_TILE_SIZE]]#2, %[[C500]]]
+//      CHECK:   %[[OUTS_PAD:.+]] = tensor.pad %[[ARG2]] low[0, 0, 0] high[%[[OUTS_PADDING_SIZE0]], %[[OUTS_PADDING_SIZE1]], %[[OUTS_PADDING_SIZE2]]]
+//      CHECK:       tensor<64x100x500xf32> to tensor<?x?x?xf32>
+//      CHECK:   %[[OUTS:.+]] = iree_linalg_ext.set_encoding %[[OUTS_PAD]]
+// CHECK-SAME:       tensor<?x?x?xf32, #iree_linalg_ext.encoding<user = BATCH_MATMUL_F32F32F32, role = RESULT, original_type = tensor<64x100x500xf32>>>
+//      CHECK:   %[[BATCH_MATMUL:.+]] = linalg.batch_matmul
+// CHECK-SAME:       ins(%[[LHS]], %[[RHS]] :
+// CHECK-SAME:       outs(%[[OUTS]] :
+//      CHECK:   %[[RESULT_PADDED:.+]] = iree_linalg_ext.unset_encoding %[[BATCH_MATMUL]]
+//      CHECK:   %[[RESULT:.+]] = tensor.extract_slice %[[RESULT_PADDED]][0, 0, 0] [64, 100, 500] [1, 1, 1]
+//      CHECK:   return %[[RESULT]]
+
+// -----
+
+func.func @batch_matmul_f32f32f32_dynamic(%arg0 : tensor<?x?x?xf32>, %arg1 : tensor<?x?x?xf32>,
+    %arg2 : tensor<?x?x?xf32>) -> tensor<?x?x?xf32> {
+  %0 = linalg.batch_matmul ins(%arg0, %arg1 : tensor<?x?x?xf32>, tensor<?x?x?xf32>)
+      outs(%arg2 : tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
+  return %0 : tensor<?x?x?xf32>
+}
+//      CHECK: #[[MAP:.+]] = affine_map<()[s0, s1] -> (-s1 + (s1 ceildiv s0) * s0)>
+//      CHECK: func @batch_matmul_f32f32f32_dynamic(
+// CHECK-SAME:     %[[ARG0:.+]]: tensor<?x?x?xf32>, %[[ARG1:.+]]: tensor<?x?x?xf32>, %[[ARG2:.+]]: tensor<?x?x?xf32>
+//  CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
+//  CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
+//  CHECK-DAG:     %[[C2:.+]] = arith.constant 2 : index
+//      CHECK:   %[[LHS_TILE_SIZE:.+]]:3 = iree_linalg_ext.upper_bound_tile_size tensor<?x?x?xf32, #iree_linalg_ext.encoding<user = BATCH_MATMUL_F32F32F32, role = LHS>> -> index, index, index
+//      CHECK:   %[[LHS_DIM0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
+//      CHECK:   %[[LHS_PADDING_SIZE0:.+]] = affine.apply #[[MAP]]()[%[[LHS_TILE_SIZE]]#0, %[[LHS_DIM0]]]
+//      CHECK:   %[[LHS_DIM1:.+]] = tensor.dim %[[ARG0]], %[[C1]]
+//      CHECK:   %[[LHS_PADDING_SIZE1:.+]] = affine.apply #[[MAP]]()[%[[LHS_TILE_SIZE]]#1, %[[LHS_DIM1]]]
+//      CHECK:   %[[LHS_DIM2:.+]] = tensor.dim %[[ARG0]], %[[C2]]
+//      CHECK:   %[[LHS_PADDING_SIZE2:.+]] = affine.apply #[[MAP]]()[%[[LHS_TILE_SIZE]]#2, %[[LHS_DIM2]]]
+//      CHECK:   %[[LHS_PAD:.+]] = tensor.pad %[[ARG0]] low[0, 0, 0] high[%[[LHS_PADDING_SIZE0]], %[[LHS_PADDING_SIZE1]], %[[LHS_PADDING_SIZE2]]]
+//      CHECK:       tensor<?x?x?xf32> to tensor<?x?x?xf32>
+//      CHECK:   %[[LHS:.+]] = iree_linalg_ext.set_encoding %[[LHS_PAD]]
+// CHECK-SAME:       tensor<?x?x?xf32, #iree_linalg_ext.encoding<user = BATCH_MATMUL_F32F32F32, role = LHS>>
+//      CHECK:   %[[RHS_TILE_SIZE:.+]]:3 = iree_linalg_ext.upper_bound_tile_size tensor<?x?x?xf32, #iree_linalg_ext.encoding<user = BATCH_MATMUL_F32F32F32, role = RHS>> -> index, index, index
+//      CHECK:   %[[RHS_DIM0:.+]] = tensor.dim %[[ARG1]], %[[C0]]
+//      CHECK:   %[[RHS_PADDING_SIZE0:.+]] = affine.apply #[[MAP]]()[%[[RHS_TILE_SIZE]]#0, %[[RHS_DIM0]]]
+//      CHECK:   %[[RHS_DIM1:.+]] = tensor.dim %[[ARG1]], %[[C1]]
+//      CHECK:   %[[RHS_PADDING_SIZE1:.+]] = affine.apply #[[MAP]]()[%[[RHS_TILE_SIZE]]#1, %[[RHS_DIM1]]]
+//      CHECK:   %[[RHS_DIM2:.+]] = tensor.dim %[[ARG1]], %[[C2]]
+//      CHECK:   %[[RHS_PADDING_SIZE2:.+]] = affine.apply #[[MAP]]()[%[[RHS_TILE_SIZE]]#2, %[[RHS_DIM2]]]
+//      CHECK:   %[[RHS_PAD:.+]] = tensor.pad %[[ARG1]] low[0, 0, 0] high[%[[RHS_PADDING_SIZE0]], %[[RHS_PADDING_SIZE1]], %[[RHS_PADDING_SIZE2]]]
+//      CHECK:       tensor<?x?x?xf32> to tensor<?x?x?xf32>
+//      CHECK:   %[[RHS:.+]] = iree_linalg_ext.set_encoding %[[RHS_PAD]]
+// CHECK-SAME:       tensor<?x?x?xf32, #iree_linalg_ext.encoding<user = BATCH_MATMUL_F32F32F32, role = RHS>>
+//      CHECK:   %[[OUTS_TILE_SIZE:.+]]:3 = iree_linalg_ext.upper_bound_tile_size tensor<?x?x?xf32, #iree_linalg_ext.encoding<user = BATCH_MATMUL_F32F32F32, role = RESULT>> -> index, index, index
+//      CHECK:   %[[OUTS_DIM0:.+]] = tensor.dim %[[ARG2]], %[[C0]]
+//      CHECK:   %[[OUTS_PADDING_SIZE0:.+]] = affine.apply #[[MAP]]()[%[[OUTS_TILE_SIZE]]#0, %[[OUTS_DIM0]]]
+//      CHECK:   %[[OUTS_DIM1:.+]] = tensor.dim %[[ARG2]], %[[C1]]
+//      CHECK:   %[[OUTS_PADDING_SIZE1:.+]] = affine.apply #[[MAP]]()[%[[OUTS_TILE_SIZE]]#1, %[[OUTS_DIM1]]]
+//      CHECK:   %[[OUTS_DIM2:.+]] = tensor.dim %[[ARG2]], %[[C2]]
+//      CHECK:   %[[OUTS_PADDING_SIZE2:.+]] = affine.apply #[[MAP]]()[%[[OUTS_TILE_SIZE]]#2, %[[OUTS_DIM2]]]
+//      CHECK:   %[[OUTS_PAD:.+]] = tensor.pad %[[ARG2]] low[0, 0, 0] high[%[[OUTS_PADDING_SIZE0]], %[[OUTS_PADDING_SIZE1]], %[[OUTS_PADDING_SIZE2]]]
+//      CHECK:       tensor<?x?x?xf32> to tensor<?x?x?xf32>
+//      CHECK:   %[[OUTS:.+]] = iree_linalg_ext.set_encoding %[[OUTS_PAD]]
+// CHECK-SAME:       tensor<?x?x?xf32, #iree_linalg_ext.encoding<user = BATCH_MATMUL_F32F32F32, role = RESULT>>
+//      CHECK:   %[[BATCH_MATMUL:.+]] = linalg.batch_matmul
+// CHECK-SAME:       ins(%[[LHS]], %[[RHS]] :
+// CHECK-SAME:       outs(%[[OUTS]] :
+//      CHECK:   %[[RESULT_PADDED:.+]] = iree_linalg_ext.unset_encoding %[[BATCH_MATMUL]]
+//      CHECK:   %[[RESULT:.+]] = tensor.extract_slice %[[RESULT_PADDED]][0, 0, 0] [{{.*}}] [1, 1, 1]
+//      CHECK:   return %[[RESULT]]
+
+// -----
+
+func.func @batch_matmul_f16f16f16(%arg0 : tensor<64x100x250xf16>, %arg1 : tensor<64x250x500xf16>,
+    %arg2 : tensor<64x100x500xf16>) -> tensor<64x100x500xf16> {
+  %0 = linalg.batch_matmul ins(%arg0, %arg1 : tensor<64x100x250xf16>, tensor<64x250x500xf16>)
+      outs(%arg2 : tensor<64x100x500xf16>) -> tensor<64x100x500xf16>
+  return %0 : tensor<64x100x500xf16>
+}
+//      CHECK: #[[MAP:.+]] = affine_map<()[s0, s1] -> (-s1 + (s1 ceildiv s0) * s0)>
+//      CHECK: func @batch_matmul_f16f16f16(
+// CHECK-SAME:     %[[ARG0:.+]]: tensor<64x100x250xf16>
+// CHECK-SAME:     %[[ARG1:.+]]: tensor<64x250x500xf16>
+// CHECK-SAME:     %[[ARG2:.+]]: tensor<64x100x500xf16>
+//  CHECK-DAG:     %[[C64:.+]] = arith.constant 64 : index
+//  CHECK-DAG:     %[[C100:.+]] = arith.constant 100 : index
+//  CHECK-DAG:     %[[C250:.+]] = arith.constant 250 : index
+//  CHECK-DAG:     %[[C500:.+]] = arith.constant 500 : index
+//      CHECK:   %[[LHS_TILE_SIZE:.+]]:3 = iree_linalg_ext.upper_bound_tile_size tensor<64x100x250xf16, #iree_linalg_ext.encoding<user = BATCH_MATMUL_F16F16F16, role = LHS>> -> index, index, index
+//      CHECK:   %[[LHS_PADDING_SIZE0:.+]] = affine.apply #[[MAP]]()[%[[LHS_TILE_SIZE]]#0, %[[C64]]]
+//      CHECK:   %[[LHS_PADDING_SIZE1:.+]] = affine.apply #[[MAP]]()[%[[LHS_TILE_SIZE]]#1, %[[C100]]]
+//      CHECK:   %[[LHS_PADDING_SIZE2:.+]] = affine.apply #[[MAP]]()[%[[LHS_TILE_SIZE]]#2, %[[C250]]]
+//      CHECK:   %[[LHS_PAD:.+]] = tensor.pad %[[ARG0]] low[0, 0, 0] high[%[[LHS_PADDING_SIZE0]], %[[LHS_PADDING_SIZE1]], %[[LHS_PADDING_SIZE2]]]
+//      CHECK:       tensor<64x100x250xf16> to tensor<?x?x?xf16>
+//      CHECK:   %[[LHS:.+]] = iree_linalg_ext.set_encoding %[[LHS_PAD]]
+// CHECK-SAME:       tensor<?x?x?xf16, #iree_linalg_ext.encoding<user = BATCH_MATMUL_F16F16F16, role = LHS, original_type = tensor<64x100x250xf16>>>
+//      CHECK:   %[[RHS_TILE_SIZE:.+]]:3 = iree_linalg_ext.upper_bound_tile_size tensor<64x250x500xf16, #iree_linalg_ext.encoding<user = BATCH_MATMUL_F16F16F16, role = RHS>> -> index, index, index
+//      CHECK:   %[[RHS_PADDING_SIZE0:.+]] = affine.apply #[[MAP]]()[%[[RHS_TILE_SIZE]]#0, %[[C64]]]
+//      CHECK:   %[[RHS_PADDING_SIZE1:.+]] = affine.apply #[[MAP]]()[%[[RHS_TILE_SIZE]]#1, %[[C250]]]
+//      CHECK:   %[[RHS_PADDING_SIZE2:.+]] = affine.apply #[[MAP]]()[%[[RHS_TILE_SIZE]]#2, %[[C500]]]
+//      CHECK:   %[[RHS_PAD:.+]] = tensor.pad %[[ARG1]] low[0, 0, 0] high[%[[RHS_PADDING_SIZE0]], %[[RHS_PADDING_SIZE1]], %[[RHS_PADDING_SIZE2]]]
+//      CHECK:       tensor<64x250x500xf16> to tensor<?x?x?xf16>
+//      CHECK:   %[[RHS:.+]] = iree_linalg_ext.set_encoding %[[RHS_PAD]]
+// CHECK-SAME:       tensor<?x?x?xf16, #iree_linalg_ext.encoding<user = BATCH_MATMUL_F16F16F16, role = RHS, original_type = tensor<64x250x500xf16>>>
+//      CHECK:   %[[OUTS_TILE_SIZE:.+]]:3 = iree_linalg_ext.upper_bound_tile_size tensor<64x100x500xf16, #iree_linalg_ext.encoding<user = BATCH_MATMUL_F16F16F16, role = RESULT>> -> index, index, index
+//      CHECK:   %[[OUTS_PADDING_SIZE0:.+]] = affine.apply #[[MAP]]()[%[[OUTS_TILE_SIZE]]#0, %[[C64]]]
+//      CHECK:   %[[OUTS_PADDING_SIZE1:.+]] = affine.apply #[[MAP]]()[%[[OUTS_TILE_SIZE]]#1, %[[C100]]]
+//      CHECK:   %[[OUTS_PADDING_SIZE2:.+]] = affine.apply #[[MAP]]()[%[[OUTS_TILE_SIZE]]#2, %[[C500]]]
+//      CHECK:   %[[OUTS_PAD:.+]] = tensor.pad %[[ARG2]] low[0, 0, 0] high[%[[OUTS_PADDING_SIZE0]], %[[OUTS_PADDING_SIZE1]], %[[OUTS_PADDING_SIZE2]]]
+//      CHECK:       tensor<64x100x500xf16> to tensor<?x?x?xf16>
+//      CHECK:   %[[OUTS:.+]] = iree_linalg_ext.set_encoding %[[OUTS_PAD]]
+// CHECK-SAME:       tensor<?x?x?xf16, #iree_linalg_ext.encoding<user = BATCH_MATMUL_F16F16F16, role = RESULT, original_type = tensor<64x100x500xf16>>>
+//      CHECK:   %[[BATCH_MATMUL:.+]] = linalg.batch_matmul
+// CHECK-SAME:       ins(%[[LHS]], %[[RHS]] :
+// CHECK-SAME:       outs(%[[OUTS]] :
+//      CHECK:   %[[RESULT_PADDED:.+]] = iree_linalg_ext.unset_encoding %[[BATCH_MATMUL]]
+//      CHECK:   %[[RESULT:.+]] = tensor.extract_slice %[[RESULT_PADDED]][0, 0, 0] [64, 100, 500] [1, 1, 1]
+//      CHECK:   return %[[RESULT]]
+
+// -----
+
+func.func @batch_matmul_f16f16f32(%arg0 : tensor<64x100x250xf16>, %arg1 : tensor<64x250x500xf16>,
+    %arg2 : tensor<64x100x500xf32>) -> tensor<64x100x500xf32> {
+  %0 = linalg.batch_matmul ins(%arg0, %arg1 : tensor<64x100x250xf16>, tensor<64x250x500xf16>)
+      outs(%arg2 : tensor<64x100x500xf32>) -> tensor<64x100x500xf32>
+  return %0 : tensor<64x100x500xf32>
+}
+//      CHECK: #[[MAP:.+]] = affine_map<()[s0, s1] -> (-s1 + (s1 ceildiv s0) * s0)>
+//      CHECK: func @batch_matmul_f16f16f32(
+// CHECK-SAME:     %[[ARG0:.+]]: tensor<64x100x250xf16>
+// CHECK-SAME:     %[[ARG1:.+]]: tensor<64x250x500xf16>
+// CHECK-SAME:     %[[ARG2:.+]]: tensor<64x100x500xf32>
+//  CHECK-DAG:     %[[C64:.+]] = arith.constant 64 : index
+//  CHECK-DAG:     %[[C100:.+]] = arith.constant 100 : index
+//  CHECK-DAG:     %[[C250:.+]] = arith.constant 250 : index
+//  CHECK-DAG:     %[[C500:.+]] = arith.constant 500 : index
+//      CHECK:   %[[LHS_TILE_SIZE:.+]]:3 = iree_linalg_ext.upper_bound_tile_size tensor<64x100x250xf16, #iree_linalg_ext.encoding<user = BATCH_MATMUL_F16F16F32, role = LHS>> -> index, index, index
+//      CHECK:   %[[LHS_PADDING_SIZE0:.+]] = affine.apply #[[MAP]]()[%[[LHS_TILE_SIZE]]#0, %[[C64]]]
+//      CHECK:   %[[LHS_PADDING_SIZE1:.+]] = affine.apply #[[MAP]]()[%[[LHS_TILE_SIZE]]#1, %[[C100]]]
+//      CHECK:   %[[LHS_PADDING_SIZE2:.+]] = affine.apply #[[MAP]]()[%[[LHS_TILE_SIZE]]#2, %[[C250]]]
+//      CHECK:   %[[LHS_PAD:.+]] = tensor.pad %[[ARG0]] low[0, 0, 0] high[%[[LHS_PADDING_SIZE0]], %[[LHS_PADDING_SIZE1]], %[[LHS_PADDING_SIZE2]]]
+//      CHECK:       tensor<64x100x250xf16> to tensor<?x?x?xf16>
+//      CHECK:   %[[LHS:.+]] = iree_linalg_ext.set_encoding %[[LHS_PAD]]
+// CHECK-SAME:       tensor<?x?x?xf16, #iree_linalg_ext.encoding<user = BATCH_MATMUL_F16F16F32, role = LHS, original_type = tensor<64x100x250xf16>>>
+//      CHECK:   %[[RHS_TILE_SIZE:.+]]:3 = iree_linalg_ext.upper_bound_tile_size tensor<64x250x500xf16, #iree_linalg_ext.encoding<user = BATCH_MATMUL_F16F16F32, role = RHS>> -> index, index, index
+//      CHECK:   %[[RHS_PADDING_SIZE0:.+]] = affine.apply #[[MAP]]()[%[[RHS_TILE_SIZE]]#0, %[[C64]]]
+//      CHECK:   %[[RHS_PADDING_SIZE1:.+]] = affine.apply #[[MAP]]()[%[[RHS_TILE_SIZE]]#1, %[[C250]]]
+//      CHECK:   %[[RHS_PADDING_SIZE2:.+]] = affine.apply #[[MAP]]()[%[[RHS_TILE_SIZE]]#2, %[[C500]]]
+//      CHECK:   %[[RHS_PAD:.+]] = tensor.pad %[[ARG1]] low[0, 0, 0] high[%[[RHS_PADDING_SIZE0]], %[[RHS_PADDING_SIZE1]], %[[RHS_PADDING_SIZE2]]]
+//      CHECK:       tensor<64x250x500xf16> to tensor<?x?x?xf16>
+//      CHECK:   %[[RHS:.+]] = iree_linalg_ext.set_encoding %[[RHS_PAD]]
+// CHECK-SAME:       tensor<?x?x?xf16, #iree_linalg_ext.encoding<user = BATCH_MATMUL_F16F16F32, role = RHS, original_type = tensor<64x250x500xf16>>>
+//      CHECK:   %[[OUTS_TILE_SIZE:.+]]:3 = iree_linalg_ext.upper_bound_tile_size tensor<64x100x500xf32, #iree_linalg_ext.encoding<user = BATCH_MATMUL_F16F16F32, role = RESULT>> -> index, index, index
+//      CHECK:   %[[OUTS_PADDING_SIZE0:.+]] = affine.apply #[[MAP]]()[%[[OUTS_TILE_SIZE]]#0, %[[C64]]]
+//      CHECK:   %[[OUTS_PADDING_SIZE1:.+]] = affine.apply #[[MAP]]()[%[[OUTS_TILE_SIZE]]#1, %[[C100]]]
+//      CHECK:   %[[OUTS_PADDING_SIZE2:.+]] = affine.apply #[[MAP]]()[%[[OUTS_TILE_SIZE]]#2, %[[C500]]]
+//      CHECK:   %[[OUTS_PAD:.+]] = tensor.pad %[[ARG2]] low[0, 0, 0] high[%[[OUTS_PADDING_SIZE0]], %[[OUTS_PADDING_SIZE1]], %[[OUTS_PADDING_SIZE2]]]
+//      CHECK:       tensor<64x100x500xf32> to tensor<?x?x?xf32>
+//      CHECK:   %[[OUTS:.+]] = iree_linalg_ext.set_encoding %[[OUTS_PAD]]
+// CHECK-SAME:       tensor<?x?x?xf32, #iree_linalg_ext.encoding<user = BATCH_MATMUL_F16F16F32, role = RESULT, original_type = tensor<64x100x500xf32>>>
+//      CHECK:   %[[BATCH_MATMUL:.+]] = linalg.batch_matmul
+// CHECK-SAME:       ins(%[[LHS]], %[[RHS]] :
+// CHECK-SAME:       outs(%[[OUTS]] :
+//      CHECK:   %[[RESULT_PADDED:.+]] = iree_linalg_ext.unset_encoding %[[BATCH_MATMUL]]
+//      CHECK:   %[[RESULT:.+]] = tensor.extract_slice %[[RESULT_PADDED]][0, 0, 0] [64, 100, 500] [1, 1, 1]
+//      CHECK:   return %[[RESULT]]
+
+// -----
+
+func.func @batch_matmul_bf16bf16bf16(%arg0 : tensor<64x100x250xbf16>, %arg1 : tensor<64x250x500xbf16>,
+    %arg2 : tensor<64x100x500xbf16>) -> tensor<64x100x500xbf16> {
+  %0 = linalg.batch_matmul ins(%arg0, %arg1 : tensor<64x100x250xbf16>, tensor<64x250x500xbf16>)
+      outs(%arg2 : tensor<64x100x500xbf16>) -> tensor<64x100x500xbf16>
+  return %0 : tensor<64x100x500xbf16>
+}
+//      CHECK: #[[MAP:.+]] = affine_map<()[s0, s1] -> (-s1 + (s1 ceildiv s0) * s0)>
+//      CHECK: func @batch_matmul_bf16bf16bf16(
+// CHECK-SAME:     %[[ARG0:.+]]: tensor<64x100x250xbf16>
+// CHECK-SAME:     %[[ARG1:.+]]: tensor<64x250x500xbf16>
+// CHECK-SAME:     %[[ARG2:.+]]: tensor<64x100x500xbf16>
+//  CHECK-DAG:     %[[C64:.+]] = arith.constant 64 : index
+//  CHECK-DAG:     %[[C100:.+]] = arith.constant 100 : index
+//  CHECK-DAG:     %[[C250:.+]] = arith.constant 250 : index
+//  CHECK-DAG:     %[[C500:.+]] = arith.constant 500 : index
+//      CHECK:   %[[LHS_TILE_SIZE:.+]]:3 = iree_linalg_ext.upper_bound_tile_size tensor<64x100x250xbf16, #iree_linalg_ext.encoding<user = BATCH_MATMUL_BF16BF16BF16, role = LHS>> -> index, index, index
+//      CHECK:   %[[LHS_PADDING_SIZE0:.+]] = affine.apply #[[MAP]]()[%[[LHS_TILE_SIZE]]#0, %[[C64]]]
+//      CHECK:   %[[LHS_PADDING_SIZE1:.+]] = affine.apply #[[MAP]]()[%[[LHS_TILE_SIZE]]#1, %[[C100]]]
+//      CHECK:   %[[LHS_PADDING_SIZE2:.+]] = affine.apply #[[MAP]]()[%[[LHS_TILE_SIZE]]#2, %[[C250]]]
+//      CHECK:   %[[LHS_PAD:.+]] = tensor.pad %[[ARG0]] low[0, 0, 0] high[%[[LHS_PADDING_SIZE0]], %[[LHS_PADDING_SIZE1]], %[[LHS_PADDING_SIZE2]]]
+//      CHECK:       tensor<64x100x250xbf16> to tensor<?x?x?xbf16>
+//      CHECK:   %[[LHS:.+]] = iree_linalg_ext.set_encoding %[[LHS_PAD]]
+// CHECK-SAME:       tensor<?x?x?xbf16, #iree_linalg_ext.encoding<user = BATCH_MATMUL_BF16BF16BF16, role = LHS, original_type = tensor<64x100x250xbf16>>>
+//      CHECK:   %[[RHS_TILE_SIZE:.+]]:3 = iree_linalg_ext.upper_bound_tile_size tensor<64x250x500xbf16, #iree_linalg_ext.encoding<user = BATCH_MATMUL_BF16BF16BF16, role = RHS>> -> index, index, index
+//      CHECK:   %[[RHS_PADDING_SIZE0:.+]] = affine.apply #[[MAP]]()[%[[RHS_TILE_SIZE]]#0, %[[C64]]]
+//      CHECK:   %[[RHS_PADDING_SIZE1:.+]] = affine.apply #[[MAP]]()[%[[RHS_TILE_SIZE]]#1, %[[C250]]]
+//      CHECK:   %[[RHS_PADDING_SIZE2:.+]] = affine.apply #[[MAP]]()[%[[RHS_TILE_SIZE]]#2, %[[C500]]]
+//      CHECK:   %[[RHS_PAD:.+]] = tensor.pad %[[ARG1]] low[0, 0, 0] high[%[[RHS_PADDING_SIZE0]], %[[RHS_PADDING_SIZE1]], %[[RHS_PADDING_SIZE2]]]
+//      CHECK:       tensor<64x250x500xbf16> to tensor<?x?x?xbf16>
+//      CHECK:   %[[RHS:.+]] = iree_linalg_ext.set_encoding %[[RHS_PAD]]
+// CHECK-SAME:       tensor<?x?x?xbf16, #iree_linalg_ext.encoding<user = BATCH_MATMUL_BF16BF16BF16, role = RHS, original_type = tensor<64x250x500xbf16>>>
+//      CHECK:   %[[OUTS_TILE_SIZE:.+]]:3 = iree_linalg_ext.upper_bound_tile_size tensor<64x100x500xbf16, #iree_linalg_ext.encoding<user = BATCH_MATMUL_BF16BF16BF16, role = RESULT>> -> index, index, index
+//      CHECK:   %[[OUTS_PADDING_SIZE0:.+]] = affine.apply #[[MAP]]()[%[[OUTS_TILE_SIZE]]#0, %[[C64]]]
+//      CHECK:   %[[OUTS_PADDING_SIZE1:.+]] = affine.apply #[[MAP]]()[%[[OUTS_TILE_SIZE]]#1, %[[C100]]]
+//      CHECK:   %[[OUTS_PADDING_SIZE2:.+]] = affine.apply #[[MAP]]()[%[[OUTS_TILE_SIZE]]#2, %[[C500]]]
+//      CHECK:   %[[OUTS_PAD:.+]] = tensor.pad %[[ARG2]] low[0, 0, 0] high[%[[OUTS_PADDING_SIZE0]], %[[OUTS_PADDING_SIZE1]], %[[OUTS_PADDING_SIZE2]]]
+//      CHECK:       tensor<64x100x500xbf16> to tensor<?x?x?xbf16>
+//      CHECK:   %[[OUTS:.+]] = iree_linalg_ext.set_encoding %[[OUTS_PAD]]
+// CHECK-SAME:       tensor<?x?x?xbf16, #iree_linalg_ext.encoding<user = BATCH_MATMUL_BF16BF16BF16, role = RESULT, original_type = tensor<64x100x500xbf16>>>
+//      CHECK:   %[[BATCH_MATMUL:.+]] = linalg.batch_matmul
+// CHECK-SAME:       ins(%[[LHS]], %[[RHS]] :
+// CHECK-SAME:       outs(%[[OUTS]] :
+//      CHECK:   %[[RESULT_PADDED:.+]] = iree_linalg_ext.unset_encoding %[[BATCH_MATMUL]]
+//      CHECK:   %[[RESULT:.+]] = tensor.extract_slice %[[RESULT_PADDED]][0, 0, 0] [64, 100, 500] [1, 1, 1]
+//      CHECK:   return %[[RESULT]]
+
+// -----
+
+func.func @batch_matmul_bf16bf16f32(%arg0 : tensor<64x100x250xbf16>, %arg1 : tensor<64x250x500xbf16>,
+    %arg2 : tensor<64x100x500xf32>) -> tensor<64x100x500xf32> {
+  %0 = linalg.batch_matmul ins(%arg0, %arg1 : tensor<64x100x250xbf16>, tensor<64x250x500xbf16>)
+      outs(%arg2 : tensor<64x100x500xf32>) -> tensor<64x100x500xf32>
+  return %0 : tensor<64x100x500xf32>
+}
+//      CHECK: #[[MAP:.+]] = affine_map<()[s0, s1] -> (-s1 + (s1 ceildiv s0) * s0)>
+//      CHECK: func @batch_matmul_bf16bf16f32(
+// CHECK-SAME:     %[[ARG0:.+]]: tensor<64x100x250xbf16>
+// CHECK-SAME:     %[[ARG1:.+]]: tensor<64x250x500xbf16>
+// CHECK-SAME:     %[[ARG2:.+]]: tensor<64x100x500xf32>
+//  CHECK-DAG:     %[[C64:.+]] = arith.constant 64 : index
+//  CHECK-DAG:     %[[C100:.+]] = arith.constant 100 : index
+//  CHECK-DAG:     %[[C250:.+]] = arith.constant 250 : index
+//  CHECK-DAG:     %[[C500:.+]] = arith.constant 500 : index
+//      CHECK:   %[[LHS_TILE_SIZE:.+]]:3 = iree_linalg_ext.upper_bound_tile_size tensor<64x100x250xbf16, #iree_linalg_ext.encoding<user = BATCH_MATMUL_BF16BF16F32, role = LHS>> -> index, index, index
+//      CHECK:   %[[LHS_PADDING_SIZE0:.+]] = affine.apply #[[MAP]]()[%[[LHS_TILE_SIZE]]#0, %[[C64]]]
+//      CHECK:   %[[LHS_PADDING_SIZE1:.+]] = affine.apply #[[MAP]]()[%[[LHS_TILE_SIZE]]#1, %[[C100]]]
+//      CHECK:   %[[LHS_PADDING_SIZE2:.+]] = affine.apply #[[MAP]]()[%[[LHS_TILE_SIZE]]#2, %[[C250]]]
+//      CHECK:   %[[LHS_PAD:.+]] = tensor.pad %[[ARG0]] low[0, 0, 0] high[%[[LHS_PADDING_SIZE0]], %[[LHS_PADDING_SIZE1]], %[[LHS_PADDING_SIZE2]]]
+//      CHECK:       tensor<64x100x250xbf16> to tensor<?x?x?xbf16>
+//      CHECK:   %[[LHS:.+]] = iree_linalg_ext.set_encoding %[[LHS_PAD]]
+// CHECK-SAME:       tensor<?x?x?xbf16, #iree_linalg_ext.encoding<user = BATCH_MATMUL_BF16BF16F32, role = LHS, original_type = tensor<64x100x250xbf16>>>
+//      CHECK:   %[[RHS_TILE_SIZE:.+]]:3 = iree_linalg_ext.upper_bound_tile_size tensor<64x250x500xbf16, #iree_linalg_ext.encoding<user = BATCH_MATMUL_BF16BF16F32, role = RHS>> -> index, index, index
+//      CHECK:   %[[RHS_PADDING_SIZE0:.+]] = affine.apply #[[MAP]]()[%[[RHS_TILE_SIZE]]#0, %[[C64]]]
+//      CHECK:   %[[RHS_PADDING_SIZE1:.+]] = affine.apply #[[MAP]]()[%[[RHS_TILE_SIZE]]#1, %[[C250]]]
+//      CHECK:   %[[RHS_PADDING_SIZE2:.+]] = affine.apply #[[MAP]]()[%[[RHS_TILE_SIZE]]#2, %[[C500]]]
+//      CHECK:   %[[RHS_PAD:.+]] = tensor.pad %[[ARG1]] low[0, 0, 0] high[%[[RHS_PADDING_SIZE0]], %[[RHS_PADDING_SIZE1]], %[[RHS_PADDING_SIZE2]]]
+//      CHECK:       tensor<64x250x500xbf16> to tensor<?x?x?xbf16>
+//      CHECK:   %[[RHS:.+]] = iree_linalg_ext.set_encoding %[[RHS_PAD]]
+// CHECK-SAME:       tensor<?x?x?xbf16, #iree_linalg_ext.encoding<user = BATCH_MATMUL_BF16BF16F32, role = RHS, original_type = tensor<64x250x500xbf16>>>
+//      CHECK:   %[[OUTS_TILE_SIZE:.+]]:3 = iree_linalg_ext.upper_bound_tile_size tensor<64x100x500xf32, #iree_linalg_ext.encoding<user = BATCH_MATMUL_BF16BF16F32, role = RESULT>> -> index, index, index
+//      CHECK:   %[[OUTS_PADDING_SIZE0:.+]] = affine.apply #[[MAP]]()[%[[OUTS_TILE_SIZE]]#0, %[[C64]]]
+//      CHECK:   %[[OUTS_PADDING_SIZE1:.+]] = affine.apply #[[MAP]]()[%[[OUTS_TILE_SIZE]]#1, %[[C100]]]
+//      CHECK:   %[[OUTS_PADDING_SIZE2:.+]] = affine.apply #[[MAP]]()[%[[OUTS_TILE_SIZE]]#2, %[[C500]]]
+//      CHECK:   %[[OUTS_PAD:.+]] = tensor.pad %[[ARG2]] low[0, 0, 0] high[%[[OUTS_PADDING_SIZE0]], %[[OUTS_PADDING_SIZE1]], %[[OUTS_PADDING_SIZE2]]]
+//      CHECK:       tensor<64x100x500xf32> to tensor<?x?x?xf32>
+//      CHECK:   %[[OUTS:.+]] = iree_linalg_ext.set_encoding %[[OUTS_PAD]]
+// CHECK-SAME:       tensor<?x?x?xf32, #iree_linalg_ext.encoding<user = BATCH_MATMUL_BF16BF16F32, role = RESULT, original_type = tensor<64x100x500xf32>>>
+//      CHECK:   %[[BATCH_MATMUL:.+]] = linalg.batch_matmul
+// CHECK-SAME:       ins(%[[LHS]], %[[RHS]] :
+// CHECK-SAME:       outs(%[[OUTS]] :
+//      CHECK:   %[[RESULT_PADDED:.+]] = iree_linalg_ext.unset_encoding %[[BATCH_MATMUL]]
+//      CHECK:   %[[RESULT:.+]] = tensor.extract_slice %[[RESULT_PADDED]][0, 0, 0] [64, 100, 500] [1, 1, 1]
+//      CHECK:   return %[[RESULT]]
+
+// -----
+
+func.func @batch_matmul_i8i8i32(%arg0 : tensor<64x100x250xi8>, %arg1 : tensor<64x250x500xi8>,
+    %arg2 : tensor<64x100x500xi32>) -> tensor<64x100x500xi32> {
+  %0 = linalg.batch_matmul ins(%arg0, %arg1 : tensor<64x100x250xi8>, tensor<64x250x500xi8>)
+      outs(%arg2 : tensor<64x100x500xi32>) -> tensor<64x100x500xi32>
+  return %0 : tensor<64x100x500xi32>
+}
+//      CHECK: #[[MAP:.+]] = affine_map<()[s0, s1] -> (-s1 + (s1 ceildiv s0) * s0)>
+//      CHECK: func @batch_matmul_i8i8i32(
+// CHECK-SAME:     %[[ARG0:.+]]: tensor<64x100x250xi8>
+// CHECK-SAME:     %[[ARG1:.+]]: tensor<64x250x500xi8>
+// CHECK-SAME:     %[[ARG2:.+]]: tensor<64x100x500xi32>
+//  CHECK-DAG:     %[[C64:.+]] = arith.constant 64 : index
+//  CHECK-DAG:     %[[C100:.+]] = arith.constant 100 : index
+//  CHECK-DAG:     %[[C250:.+]] = arith.constant 250 : index
+//  CHECK-DAG:     %[[C500:.+]] = arith.constant 500 : index
+//      CHECK:   %[[LHS_TILE_SIZE:.+]]:3 = iree_linalg_ext.upper_bound_tile_size tensor<64x100x250xi8, #iree_linalg_ext.encoding<user = BATCH_MATMUL_I8I8I32, role = LHS>> -> index, index, index
+//      CHECK:   %[[LHS_PADDING_SIZE0:.+]] = affine.apply #[[MAP]]()[%[[LHS_TILE_SIZE]]#0, %[[C64]]]
+//      CHECK:   %[[LHS_PADDING_SIZE1:.+]] = affine.apply #[[MAP]]()[%[[LHS_TILE_SIZE]]#1, %[[C100]]]
+//      CHECK:   %[[LHS_PADDING_SIZE2:.+]] = affine.apply #[[MAP]]()[%[[LHS_TILE_SIZE]]#2, %[[C250]]]
+//      CHECK:   %[[LHS_PAD:.+]] = tensor.pad %[[ARG0]] low[0, 0, 0] high[%[[LHS_PADDING_SIZE0]], %[[LHS_PADDING_SIZE1]], %[[LHS_PADDING_SIZE2]]]
+//      CHECK:       tensor<64x100x250xi8> to tensor<?x?x?xi8>
+//      CHECK:   %[[LHS:.+]] = iree_linalg_ext.set_encoding %[[LHS_PAD]]
+// CHECK-SAME:       tensor<?x?x?xi8, #iree_linalg_ext.encoding<user = BATCH_MATMUL_I8I8I32, role = LHS, original_type = tensor<64x100x250xi8>>>
+//      CHECK:   %[[RHS_TILE_SIZE:.+]]:3 = iree_linalg_ext.upper_bound_tile_size tensor<64x250x500xi8, #iree_linalg_ext.encoding<user = BATCH_MATMUL_I8I8I32, role = RHS>> -> index, index, index
+//      CHECK:   %[[RHS_PADDING_SIZE0:.+]] = affine.apply #[[MAP]]()[%[[RHS_TILE_SIZE]]#0, %[[C64]]]
+//      CHECK:   %[[RHS_PADDING_SIZE1:.+]] = affine.apply #[[MAP]]()[%[[RHS_TILE_SIZE]]#1, %[[C250]]]
+//      CHECK:   %[[RHS_PADDING_SIZE2:.+]] = affine.apply #[[MAP]]()[%[[RHS_TILE_SIZE]]#2, %[[C500]]]
+//      CHECK:   %[[RHS_PAD:.+]] = tensor.pad %[[ARG1]] low[0, 0, 0] high[%[[RHS_PADDING_SIZE0]], %[[RHS_PADDING_SIZE1]], %[[RHS_PADDING_SIZE2]]]
+//      CHECK:       tensor<64x250x500xi8> to tensor<?x?x?xi8>
+//      CHECK:   %[[RHS:.+]] = iree_linalg_ext.set_encoding %[[RHS_PAD]]
+// CHECK-SAME:       tensor<?x?x?xi8, #iree_linalg_ext.encoding<user = BATCH_MATMUL_I8I8I32, role = RHS, original_type = tensor<64x250x500xi8>>>
+//      CHECK:   %[[OUTS_TILE_SIZE:.+]]:3 = iree_linalg_ext.upper_bound_tile_size tensor<64x100x500xi32, #iree_linalg_ext.encoding<user = BATCH_MATMUL_I8I8I32, role = RESULT>> -> index, index, index
+//      CHECK:   %[[OUTS_PADDING_SIZE0:.+]] = affine.apply #[[MAP]]()[%[[OUTS_TILE_SIZE]]#0, %[[C64]]]
+//      CHECK:   %[[OUTS_PADDING_SIZE1:.+]] = affine.apply #[[MAP]]()[%[[OUTS_TILE_SIZE]]#1, %[[C100]]]
+//      CHECK:   %[[OUTS_PADDING_SIZE2:.+]] = affine.apply #[[MAP]]()[%[[OUTS_TILE_SIZE]]#2, %[[C500]]]
+//      CHECK:   %[[OUTS_PAD:.+]] = tensor.pad %[[ARG2]] low[0, 0, 0] high[%[[OUTS_PADDING_SIZE0]], %[[OUTS_PADDING_SIZE1]], %[[OUTS_PADDING_SIZE2]]]
+//      CHECK:       tensor<64x100x500xi32> to tensor<?x?x?xi32>
+//      CHECK:   %[[OUTS:.+]] = iree_linalg_ext.set_encoding %[[OUTS_PAD]]
+// CHECK-SAME:       tensor<?x?x?xi32, #iree_linalg_ext.encoding<user = BATCH_MATMUL_I8I8I32, role = RESULT, original_type = tensor<64x100x500xi32>>>
+//      CHECK:   %[[BATCH_MATMUL:.+]] = linalg.batch_matmul
+// CHECK-SAME:       ins(%[[LHS]], %[[RHS]] :
+// CHECK-SAME:       outs(%[[OUTS]] :
+//      CHECK:   %[[RESULT_PADDED:.+]] = iree_linalg_ext.unset_encoding %[[BATCH_MATMUL]]
+//      CHECK:   %[[RESULT:.+]] = tensor.extract_slice %[[RESULT_PADDED]][0, 0, 0] [64, 100, 500] [1, 1, 1]
+//      CHECK:   return %[[RESULT]]
+
+// -----
+
 func.func @fold_fill_with_set_encoding(%arg0 : index, %arg1 : index)
   -> tensor<?x?xf32, #iree_linalg_ext.encoding<user = MATMUL_F32F32F32, role = LHS>> {
   %cst = arith.constant 0.0 : f32

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
@@ -1518,13 +1518,16 @@ void populateStreamToHALPatterns(MLIRContext *context,
   patterns.insert<GlobalTimepointConversionPattern>(typeConverter, context);
 
   auto mapping = std::make_shared<StreamConversionMapping>();
+
   patterns.insert<ResourceAllocOpPattern, ResourceAllocaOpPattern,
                   ResourceDeallocaOpPattern, ResourceSizeOpPattern,
                   ResourceTryMapOpPattern, ResourceLoadOpPattern,
                   ResourceStoreOpPattern, ResourceSubviewOpPattern>(
       mapping, typeConverter, context);
+
   patterns.insert<FileConstantOpPattern, FileReadOpPattern, FileWriteOpPattern>(
       mapping, typeConverter, context);
+
   patterns.insert<TensorImportBufferOpPattern, TensorImportBufferViewOpPattern,
                   TensorExportBufferOpPattern, TensorExportBufferViewOpPattern,
                   TensorTraceOpPattern>(mapping, typeConverter, context);

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/schedule_concurrency.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/schedule_concurrency.mlir
@@ -103,6 +103,31 @@ func.func @partitioningForMaxConcurrency(%arg0: !stream.resource<external>, %arg
 
 // -----
 
+// Tests that tied operands properly trigger hazard detection.
+// Here @dispatch_1 has a read/write hazard on %capture0 with @dispatch_0 and
+// should not be placed into the same concurrency group.
+
+// CHECK-LABEL: @keepTiedOpsSeparate
+// CHECK-SAME: (%[[ARG0:.+]]: !stream.resource<external>)
+func.func @keepTiedOpsSeparate(%arg0: !stream.resource<external>) -> (!stream.resource<external>, !stream.resource<external>) {
+  %c0 = arith.constant 0 : index
+  %c4 = arith.constant 4 : index
+  // CHECK: stream.async.execute
+  // CHECK-SAME: with(%[[ARG0]] as %[[CAPTURE0:.+]]: !stream.resource<external>{%c4}) ->
+  %results:2, %result_timepoint = stream.async.execute with(%arg0 as %capture0: !stream.resource<external>{%c4}) -> (!stream.resource<external>{%c4}, %arg0{%c4}) {
+    // CHECK-NOT: stream.async.concurrent
+    // CHECK-NEXT: stream.async.dispatch @ex::@dispatch_0
+    %1 = stream.async.dispatch @ex::@dispatch_0(%capture0[%c0 to %c4 for %c4]) : (!stream.resource<external>{%c4}) -> !stream.resource<external>{%c4}
+    // CHECK-NEXT: stream.async.dispatch @ex::@dispatch_1
+    %2 = stream.async.dispatch @ex::@dispatch_1(%capture0[%c0 to %c4 for %c4]) : (!stream.resource<external>{%c4}) -> %capture0{%c4}
+    // CHECK-NEXT: stream.yield
+    stream.yield %1, %2 : !stream.resource<external>{%c4}, !stream.resource<external>{%c4}
+  } => !stream.timepoint
+  return %results#0, %results#1 : !stream.resource<external>, !stream.resource<external>
+}
+
+// -----
+
 // TODO(#11249): add a test for in-place collectives (send == recv).
 
 // Tests that multiple collective ops will get grouped together in a concurrent

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
@@ -39,8 +39,7 @@ static void buildVectorVMVXTransformPassPipeline(OpPassManager &passManager) {
       createCPUMaterializeEncodingPass());
   // TODO: Remove the following pass the plumb support for #hal.descriptor_type
   // memory space through the stack.
-  passManager.nest<ModuleOp>().addNestedPass<func::FuncOp>(
-      createEraseHALDescriptorTypeFromMemRefPass());
+  passManager.addPass(createEraseHALDescriptorTypeFromMemRefPass());
   passManager.addPass(createLLVMCPULowerExecutableTargetPass());
 
   OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();

--- a/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
+++ b/compiler/src/iree/compiler/GlobalOptimization/Passes.cpp
@@ -54,8 +54,6 @@ void buildGlobalOptimizationPassPipeline(
   // Expand tensor shapes into SSA values and optimize the whole program.
   // The more we are able to equate shape dimensions at this level the
   // better our fusions will be.
-  FunctionLikeNest(mainPassManager)
-      .addPass(IREE::Flow::createTopLevelSCFToCFGPass);
   mainPassManager.addPass(IREE::Flow::createExpandTensorShapesPass());
 
   FunctionLikeNest(mainPassManager)

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/StreamToHALInline/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/StreamToHALInline/test/BUILD.bazel
@@ -17,6 +17,7 @@ iree_lit_test_suite(
     srcs = enforce_glob(
         [
             "cmd_ops.mlir",
+            "file_ops.mlir",
             "resource_ops.mlir",
             "timepoint_ops.mlir",
             "transfer_ops.mlir",

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/StreamToHALInline/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/StreamToHALInline/test/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "cmd_ops.mlir"
+    "file_ops.mlir"
     "resource_ops.mlir"
     "timepoint_ops.mlir"
     "transfer_ops.mlir"

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/StreamToHALInline/test/file_ops.mlir
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/StreamToHALInline/test/file_ops.mlir
@@ -1,0 +1,44 @@
+// RUN: iree-opt --split-input-file --iree-hal-inline-conversion %s | FileCheck %s
+
+// NOTE: file ops are not available under the inline HAL and are all no-oped.
+// This works today because file ops are only used as a fallback for direct
+// resource importing. If an input program relied on file ops for user behavior
+// we'd need to support them and expose them through the runtime HAL module.
+
+// CHECK-LABEL: @file_constant
+//  CHECK-SAME: (%[[BUFFER:.+]]: !util.buffer)
+func.func @file_constant(%buffer: !util.buffer) {
+  %c0 = arith.constant 0 : index
+  %c1088 = arith.constant 1088 : index
+  // CHECK: = arith.constant 0 : i32
+  %file = stream.file.constant %buffer[%c0 for %c1088] : !util.buffer{%c1088} -> !stream.file
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @file_read
+//  CHECK-SAME: (%[[WAIT:.+]]: i64, %[[FILE:.+]]: i32, %[[RESOURCE:.+]]: !util.buffer)
+func.func @file_read(%wait: !stream.timepoint, %file: !stream.file, %resource: !stream.resource<variable>) -> !stream.timepoint {
+  %c0 = arith.constant 0 : index
+  %offset = arith.constant 100 : i64
+  %c1088 = arith.constant 1088 : index
+  // CHECK: %[[SIGNAL:.+]] = arith.constant 0 : i64
+  %signal = stream.file.read await(%wait) => %file[%offset], %resource[%c0], %c1088 : !stream.file -> !stream.resource<variable>{%c1088} => !stream.timepoint
+  // CHECK: return %[[SIGNAL]]
+  return %signal : !stream.timepoint
+}
+
+// -----
+
+// CHECK-LABEL: @file_write
+//  CHECK-SAME: (%[[WAIT:.+]]: i64, %[[FILE:.+]]: i32, %[[RESOURCE:.+]]: !util.buffer)
+func.func @file_write(%wait: !stream.timepoint, %file: !stream.file, %resource: !stream.resource<variable>) -> !stream.timepoint {
+  %c0 = arith.constant 0 : index
+  %offset = arith.constant 100 : i64
+  %c1088 = arith.constant 1088 : index
+  // CHECK: %[[SIGNAL:.+]] = arith.constant 0 : i64
+  %signal = stream.file.write await(%wait) => %resource[%c0], %file[%offset], %c1088 : !stream.resource<variable>{%c1088} -> !stream.file => !stream.timepoint
+  // CHECK: return %[[SIGNAL]]
+  return %signal : !stream.timepoint
+}

--- a/docs/website/docs/building-from-source/android.md
+++ b/docs/website/docs/building-from-source/android.md
@@ -18,7 +18,7 @@ system architecture):
   either pushed to the target to run natively or is bundled into an Android
   [APK](https://en.wikipedia.org/wiki/Android_application_package)
 
-## Prerequisites
+## :octicons-download-16: Prerequisites
 
 ### Host environment setup
 
@@ -43,7 +43,7 @@ ADB (the Android Debug Bridge) is also needed to communicate with Android
 devices from the command line. Install it following the
 [official user guide](https://developer.android.com/studio/command-line/adb).
 
-## Configure and build
+## :octicons-sliders-16: Configure and build
 
 ### Host configuration
 
@@ -110,22 +110,29 @@ Build the runtime using the Android NDK toolchain:
     The specific `ANDROID_ABI` and `ANDROID_PLATFORM` used should match your
     target device.
 
-## Running Android tests
+## :octicons-code-16: Running Android tests
 
 Make sure you
 [enable developer options and USB debugging](https://developer.android.com/studio/debug/dev-options#enable)
 on your Android device and can see your it when you run `adb devices`, then run
-all built tests through
-[CTest](https://gitlab.kitware.com/cmake/community/-/wikis/doc/ctest/Testing-With-CTest):
+all tests through
+[ctest](https://cmake.org/cmake/help/latest/manual/ctest.1.html):
 
 ``` shell
+# Build test dependencies
+cmake --build ../iree-build-android/ --target iree-test-deps
+
+# Ensure that your Android device is visible
+adb devices
+
+# Run tests
 ctest --test-dir ../iree-build-android/ --output-on-failure
 ```
 
 This will automatically upload build artifacts to the connected Android device,
 run the tests, then report the status back to your host machine.
 
-## Running tools directly
+## :octicons-code-16: Running tools directly
 
 Invoke the host compiler tools to produce a bytecode module FlatBuffer:
 

--- a/docs/website/docs/building-from-source/getting-started.md
+++ b/docs/website/docs/building-from-source/getting-started.md
@@ -258,7 +258,7 @@ about the bindings themselves.
 
 ### Dependencies
 
-You will need a recent Python installation >=3.8 (we aim to support
+You will need a recent Python installation >=3.9 (we aim to support
 [non-eol Python versions](https://endoflife.date/python)).
 
 ???+ Tip "Tip - Managing Python versions"

--- a/experimental/cuda2/README.md
+++ b/experimental/cuda2/README.md
@@ -107,7 +107,9 @@ instead:
 
 * We keep track of all GPU signals in the timeline. Once we see a GPU wait
   request, try to scan the timeline to find a GPU signal that advances the
-  timeline past the desired value, and use that for waiting instead.
+  timeline past the desired value, and use that for waiting instead. (This
+  actually applies to CPU waits too, and it's an optimization over pure
+  CPU side `iree_event_t` polling.)
 * We may not see GPU signal before seeing GPU wait requests, then we can also
   keep track of all GPU waits in the timeline. Later once see either a CPU
   signal or GPU signal advancing past the waited value, we can handle them

--- a/experimental/cuda2/event_semaphore.c
+++ b/experimental/cuda2/event_semaphore.c
@@ -225,6 +225,37 @@ static iree_status_t iree_hal_cuda2_semaphore_acquire_timepoint_host_wait(
   return iree_ok_status();
 }
 
+// Acquires an iree_hal_cuda2_event_t object to wait on the host for the
+// timeline to reach at least the given |min_value| on the device.
+// Returns true and writes to |out_event| if we can find such an event;
+// returns false otherwise.
+// The caller should release the |out_event| once done.
+static bool iree_hal_cuda2_semaphore_acquire_event_host_wait(
+    iree_hal_cuda2_semaphore_t* semaphore, uint64_t min_value,
+    iree_hal_cuda2_event_t** out_event) {
+  *out_event = NULL;
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Scan through the timepoint list and try to find a device event signal to
+  // wait on. We need to lock with the timepoint list mutex here.
+  iree_slim_mutex_lock(&semaphore->base.timepoint_mutex);
+  for (iree_hal_semaphore_timepoint_t* tp = semaphore->base.timepoint_list.head;
+       tp != NULL; tp = tp->next) {
+    iree_hal_cuda2_timepoint_t* signal_timepoint =
+        (iree_hal_cuda2_timepoint_t*)tp;
+    if (signal_timepoint->kind == IREE_HAL_CUDA_TIMEPOINT_KIND_DEVICE_SIGNAL &&
+        signal_timepoint->base.minimum_value >= min_value) {
+      *out_event = signal_timepoint->timepoint.device_signal;
+      iree_hal_cuda2_event_retain(*out_event);
+      break;
+    }
+  }
+  iree_slim_mutex_unlock(&semaphore->base.timepoint_mutex);
+
+  IREE_TRACE_ZONE_END(z0);
+  return *out_event != NULL;
+}
+
 static iree_status_t iree_hal_cuda2_semaphore_wait(
     iree_hal_semaphore_t* base_semaphore, uint64_t value,
     iree_timeout_t timeout) {
@@ -254,6 +285,21 @@ static iree_status_t iree_hal_cuda2_semaphore_wait(
   iree_slim_mutex_unlock(&semaphore->mutex);
 
   iree_time_t deadline_ns = iree_timeout_as_deadline_ns(timeout);
+
+  // Slow path: try to see if we can have a device CUevent to wait on. This
+  // should happen outside of the lock given that acquiring has its own internal
+  // locks. This is faster than waiting on a host timepoint.
+  iree_hal_cuda2_event_t* wait_event = NULL;
+  if (iree_hal_cuda2_semaphore_acquire_event_host_wait(semaphore, value,
+                                                       &wait_event)) {
+    IREE_CUDA_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, semaphore->symbols,
+        cuEventSynchronize(iree_hal_cuda2_event_handle(wait_event)),
+        "cuEventSynchronize");
+    iree_hal_cuda2_event_release(wait_event);
+    IREE_TRACE_ZONE_END(z0);
+    return iree_ok_status();
+  }
 
   // Slow path: acquire a timepoint. This should happen outside of the lock to
   // given that acquiring has its own internal locks.
@@ -380,25 +426,15 @@ iree_status_t iree_hal_cuda2_event_semaphore_acquire_timepoint_device_wait(
       },
       &wait_timepoint->base);
 
-  // Scan through the timepoint list and try to find a device event signal to
-  // wait on. We need to lock with the timepoint list mutex here.
-  iree_slim_mutex_lock(&semaphore->base.timepoint_mutex);
-  for (iree_hal_semaphore_timepoint_t* tp = semaphore->base.timepoint_list.head;
-       tp != NULL; tp = tp->next) {
-    iree_hal_cuda2_timepoint_t* signal_timepoint =
-        (iree_hal_cuda2_timepoint_t*)tp;
-    if (signal_timepoint->kind == IREE_HAL_CUDA_TIMEPOINT_KIND_DEVICE_SIGNAL &&
-        signal_timepoint->base.minimum_value >= min_value) {
-      // We've found an existing signal timepoint to wait on; we don't need a
-      // standalone wait timepoint anymore. Decrease its refcount before
-      // overwriting it to return it back to the pool and retain the new one.
-      iree_hal_cuda2_event_release(wait_timepoint->timepoint.device_wait);
-      iree_hal_cuda2_event_t* event = signal_timepoint->timepoint.device_signal;
-      iree_hal_cuda2_event_retain(event);
-      wait_timepoint->timepoint.device_wait = event;
-    }
+  iree_hal_cuda2_event_t* wait_event = NULL;
+  if (iree_hal_cuda2_semaphore_acquire_event_host_wait(semaphore, min_value,
+                                                       &wait_event)) {
+    // We've found an existing signal timepoint to wait on; we don't need a
+    // standalone wait timepoint anymore. Decrease its refcount before
+    // overwriting it to return it back to the pool and retain the existing one.
+    iree_hal_cuda2_event_release(wait_timepoint->timepoint.device_wait);
+    wait_timepoint->timepoint.device_wait = wait_event;
   }
-  iree_slim_mutex_unlock(&semaphore->base.timepoint_mutex);
 
   *out_event =
       iree_hal_cuda2_event_handle(wait_timepoint->timepoint.device_wait);

--- a/experimental/cuda2/event_semaphore.h
+++ b/experimental/cuda2/event_semaphore.h
@@ -43,7 +43,7 @@ iree_status_t iree_hal_cuda2_event_semaphore_acquire_timepoint_device_signal(
     CUevent* out_event);
 
 // Acquires a timepoint to wait the timeline to reach at least the given
-// |min_value| on the device The underlying CUDA event is written into
+// |min_value| on the device. The underlying CUDA event is written into
 // |out_event| for interacting with CUDA APIs.
 iree_status_t iree_hal_cuda2_event_semaphore_acquire_timepoint_device_wait(
     iree_hal_semaphore_t* base_semaphore, uint64_t min_value,

--- a/integrations/tensorflow/python_projects/iree_tf/setup.py
+++ b/integrations/tensorflow/python_projects/iree_tf/setup.py
@@ -55,11 +55,10 @@ setup(
         "Development Status :: 3 - Alpha",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     packages=find_namespace_packages(
         include=[
             "iree.tools.tf",

--- a/integrations/tensorflow/python_projects/iree_tflite/setup.py
+++ b/integrations/tensorflow/python_projects/iree_tflite/setup.py
@@ -55,11 +55,10 @@ setup(
         "Development Status :: 3 - Alpha",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     packages=find_namespace_packages(
         include=[
             "iree.tools.tflite",

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/MaterializeEncoding.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/MaterializeEncoding.cpp
@@ -222,6 +222,12 @@ static FailureOr<SmallVector<Value>> lowerUpperBoundTileSizeOpToConstants(
     results[innerDimsPos[i]] =
         rewriter.create<arith::ConstantIndexOp>(loc, tileSize);
   }
+  // For the dims that have no inner tiles, use 1 as tile size to avoid padding.
+  for (unsigned i = 0; i < results.size(); ++i) {
+    if (!results[i]) {
+      results[i] = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    }
+  }
   return results;
 }
 

--- a/runtime/setup.py
+++ b/runtime/setup.py
@@ -517,13 +517,12 @@ setup(
         "Development Status :: 3 - Alpha",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
     ],
     url="https://github.com/openxla/iree",
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     ext_modules=(
         [
             CMakeExtension("iree._runtime_libs._runtime"),

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64.c
@@ -9,15 +9,14 @@
 
 void iree_uk_mmt4d_tile_f32f32f32_8x8x1_arm_64(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
-  (void)params;
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   const float* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const float* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
   float* IREE_UK_RESTRICT out_ptr = out_tile;
   float32x4_t acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7, acc8, acc9, acc10,
       acc11, acc12, acc13, acc14, acc15;
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     acc0 = vld1q_f32(out_ptr + 4 * 0);
     acc1 = vld1q_f32(out_ptr + 4 * 1);
     acc2 = vld1q_f32(out_ptr + 4 * 2);
@@ -52,8 +51,8 @@ void iree_uk_mmt4d_tile_f32f32f32_8x8x1_arm_64(
     acc14 = vdupq_n_f32(0);
     acc15 = vdupq_n_f32(0);
   }
-  IREE_UK_ASSUME(K >= 1);
-  for (int k = 0; k < K; ++k) {
+  IREE_UK_ASSUME(params->K >= 1);
+  for (int k = 0; k < params->K; ++k) {
     float32x4_t lhs0 = vld1q_f32(lhs_ptr + 0);
     float32x4_t lhs1 = vld1q_f32(lhs_ptr + 4);
     lhs_ptr += 8;
@@ -100,15 +99,13 @@ void iree_uk_mmt4d_tile_f32f32f32_8x8x1_arm_64(
 // should only be used if IREE_UK_FLAG_MMT4D_SKIP_INTERMEDIATE_ROUNDINGS is set.
 static void iree_uk_mmt4d_tile_f16f16fXX_8x8x1_arm_64(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params,
-    iree_uk_type_t acc_type) {
-  (void)params;
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params, iree_uk_type_t acc_type) {
   const float16_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const float16_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
   float32x4_t acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7, acc8, acc9, acc10,
       acc11, acc12, acc13, acc14, acc15;
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     if (acc_type == IREE_UK_TYPE_FLOAT_32) {
       float* IREE_UK_RESTRICT out_ptr = out_tile;
       acc0 = vld1q_f32(out_ptr + 4 * 0);
@@ -164,8 +161,8 @@ static void iree_uk_mmt4d_tile_f16f16fXX_8x8x1_arm_64(
     acc14 = vdupq_n_f32(0);
     acc15 = vdupq_n_f32(0);
   }
-  IREE_UK_ASSUME(K >= 1);
-  for (int k = 0; k < K; ++k) {
+  IREE_UK_ASSUME(params->K >= 1);
+  for (int k = 0; k < params->K; ++k) {
     float32x4_t lhs0 = vcvt_f32_f16(vld1_f16(lhs_ptr + 0));
     float32x4_t lhs1 = vcvt_f32_f16(vld1_f16(lhs_ptr + 4));
     lhs_ptr += 8;
@@ -230,31 +227,30 @@ static void iree_uk_mmt4d_tile_f16f16fXX_8x8x1_arm_64(
 
 void iree_uk_mmt4d_tile_f16f16f16_8x8x1_arm_64(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
-  iree_uk_mmt4d_tile_f16f16fXX_8x8x1_arm_64(
-      out_tile, lhs_panel, rhs_panel, K, flags, params, IREE_UK_TYPE_FLOAT_16);
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
+  iree_uk_mmt4d_tile_f16f16fXX_8x8x1_arm_64(out_tile, lhs_panel, rhs_panel,
+                                            params, IREE_UK_TYPE_FLOAT_16);
 }
 
 void iree_uk_mmt4d_tile_f16f16f32_8x8x1_arm_64(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
-  iree_uk_mmt4d_tile_f16f16fXX_8x8x1_arm_64(
-      out_tile, lhs_panel, rhs_panel, K, flags, params, IREE_UK_TYPE_FLOAT_32);
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
+  iree_uk_mmt4d_tile_f16f16fXX_8x8x1_arm_64(out_tile, lhs_panel, rhs_panel,
+                                            params, IREE_UK_TYPE_FLOAT_32);
 }
 
 void iree_uk_mmt4d_tile_i8i8i32_8x8x1_arm_64(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
-  (void)params;
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   const iree_uk_int8_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const iree_uk_int8_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
   iree_uk_int32_t* IREE_UK_RESTRICT out_ptr = out_tile;
   int32x4_t acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7, acc8, acc9, acc10,
       acc11, acc12, acc13, acc14, acc15;
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     acc0 = vld1q_s32(out_ptr + 4 * 0);
     acc1 = vld1q_s32(out_ptr + 4 * 1);
     acc2 = vld1q_s32(out_ptr + 4 * 2);
@@ -289,8 +285,8 @@ void iree_uk_mmt4d_tile_i8i8i32_8x8x1_arm_64(
     acc14 = vdupq_n_s32(0);
     acc15 = vdupq_n_s32(0);
   }
-  IREE_UK_ASSUME(K >= 1);
-  for (int k = 0; k < K; ++k) {
+  IREE_UK_ASSUME(params->K >= 1);
+  for (int k = 0; k < params->K; ++k) {
     int16x8_t lhs = vmovl_s8(vld1_s8(lhs_ptr));
     lhs_ptr += 8;
     int16x8_t rhs = vmovl_s8(vld1_s8(rhs_ptr));

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_bf16.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_bf16.c
@@ -33,9 +33,8 @@ static inline float32x4_t iree_uk_neon_uzp2_f32_as_s64(float32x4_t a,
 
 void iree_uk_mmt4d_tile_bf16bf16f32_8x8x4_arm_64_bf16(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
-  (void)params;
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   const bfloat16_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const bfloat16_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
   float* IREE_UK_RESTRICT out_ptr = out_tile;
@@ -43,7 +42,7 @@ void iree_uk_mmt4d_tile_bf16bf16f32_8x8x4_arm_64_bf16(
   float32x4_t acc_23_01, acc_23_23, acc_23_45, acc_23_67;
   float32x4_t acc_45_01, acc_45_23, acc_45_45, acc_45_67;
   float32x4_t acc_67_01, acc_67_23, acc_67_45, acc_67_67;
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     float32x4_t acc_0_0123 = vld1q_f32(out_ptr + 8 * 0 + 0);
     float32x4_t acc_0_4567 = vld1q_f32(out_ptr + 8 * 0 + 4);
     float32x4_t acc_1_0123 = vld1q_f32(out_ptr + 8 * 1 + 0);
@@ -95,8 +94,8 @@ void iree_uk_mmt4d_tile_bf16bf16f32_8x8x4_arm_64_bf16(
     acc_67_67 = vdupq_n_f32(0);
   }
 
-  IREE_UK_ASSUME(K >= 1);
-  for (int k = 0; k < K; ++k) {
+  IREE_UK_ASSUME(params->K >= 1);
+  for (int k = 0; k < params->K; ++k) {
     bfloat16x8_t lhs01 = vld1q_bf16(lhs_ptr + 0);
     bfloat16x8_t lhs23 = vld1q_bf16(lhs_ptr + 8);
     bfloat16x8_t lhs45 = vld1q_bf16(lhs_ptr + 16);

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_dotprod.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_dotprod.c
@@ -9,15 +9,14 @@
 
 void iree_uk_mmt4d_tile_i8i8i32_8x8x4_arm_64_dotprod(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
-  (void)params;
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   const iree_uk_int8_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const iree_uk_int8_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
   iree_uk_int32_t* IREE_UK_RESTRICT out_ptr = out_tile;
   int32x4_t acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7, acc8, acc9, acc10,
       acc11, acc12, acc13, acc14, acc15;
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     acc0 = vld1q_s32(out_ptr + 4 * 0);
     acc1 = vld1q_s32(out_ptr + 4 * 1);
     acc2 = vld1q_s32(out_ptr + 4 * 2);
@@ -52,8 +51,8 @@ void iree_uk_mmt4d_tile_i8i8i32_8x8x4_arm_64_dotprod(
     acc14 = vdupq_n_s32(0);
     acc15 = vdupq_n_s32(0);
   }
-  IREE_UK_ASSUME(K >= 1);
-  for (int k = 0; k < K; ++k) {
+  IREE_UK_ASSUME(params->K >= 1);
+  for (int k = 0; k < params->K; ++k) {
     int8x16_t lhs0 = vld1q_s8(lhs_ptr + 0);
     int8x16_t lhs1 = vld1q_s8(lhs_ptr + 16);
     lhs_ptr += 32;

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_fp16.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_fp16.c
@@ -9,14 +9,13 @@
 
 void iree_uk_mmt4d_tile_f16f16f16_8x8x1_arm_64_fp16(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
-  (void)params;
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   float16_t* IREE_UK_RESTRICT out_ptr = out_tile;
   const float16_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const float16_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
   float16x8_t acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7;
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     acc0 = vld1q_f16(out_ptr + 8 * 0);
     acc1 = vld1q_f16(out_ptr + 8 * 1);
     acc2 = vld1q_f16(out_ptr + 8 * 2);
@@ -35,8 +34,8 @@ void iree_uk_mmt4d_tile_f16f16f16_8x8x1_arm_64_fp16(
     acc6 = vdupq_n_f16(0);
     acc7 = vdupq_n_f16(0);
   }
-  IREE_UK_ASSUME(K >= 1);
-  for (int k = 0; k < K; ++k) {
+  IREE_UK_ASSUME(params->K >= 1);
+  for (int k = 0; k < params->K; ++k) {
     float16x8_t lhs = vld1q_f16(lhs_ptr);
     lhs_ptr += 8;
     float16x8_t rhs = vld1q_f16(rhs_ptr);

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_fp16fml.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_fp16fml.c
@@ -37,15 +37,14 @@
 
 void iree_uk_mmt4d_tile_f16f16f32_8x8x1_arm_64_fp16fml(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
-  (void)params;
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   float* IREE_UK_RESTRICT out_ptr = out_tile;
   const float16_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const float16_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
   float32x4_t acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7, acc8, acc9, acc10,
       acc11, acc12, acc13, acc14, acc15;
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     acc0 = vld1q_f32(out_ptr + 4 * 0);
     acc1 = vld1q_f32(out_ptr + 4 * 1);
     acc2 = vld1q_f32(out_ptr + 4 * 2);
@@ -80,8 +79,8 @@ void iree_uk_mmt4d_tile_f16f16f32_8x8x1_arm_64_fp16fml(
     acc14 = vdupq_n_f32(0);
     acc15 = vdupq_n_f32(0);
   }
-  IREE_UK_ASSUME(K >= 1);
-  for (int k = 0; k < K; ++k) {
+  IREE_UK_ASSUME(params->K >= 1);
+  for (int k = 0; k < params->K; ++k) {
     float16x8_t lhs = vld1q_f16(lhs_ptr);
     lhs_ptr += 8;
     float16x8_t rhs = vld1q_f16(rhs_ptr);

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_i8mm.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64_i8mm.c
@@ -29,9 +29,8 @@ static inline int32x4_t iree_uk_neon_uzp2_s32_as_s64(int32x4_t a, int32x4_t b) {
 
 void iree_uk_mmt4d_tile_i8i8i32_8x8x8_arm_64_i8mm(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
-  (void)params;
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   const iree_uk_int8_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const iree_uk_int8_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
   iree_uk_int32_t* IREE_UK_RESTRICT out_ptr = out_tile;
@@ -39,7 +38,7 @@ void iree_uk_mmt4d_tile_i8i8i32_8x8x8_arm_64_i8mm(
   int32x4_t acc_23_01, acc_23_23, acc_23_45, acc_23_67;
   int32x4_t acc_45_01, acc_45_23, acc_45_45, acc_45_67;
   int32x4_t acc_67_01, acc_67_23, acc_67_45, acc_67_67;
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     int32x4_t acc_0_0123 = vld1q_s32(out_ptr + 8 * 0 + 0);
     int32x4_t acc_0_4567 = vld1q_s32(out_ptr + 8 * 0 + 4);
     int32x4_t acc_1_0123 = vld1q_s32(out_ptr + 8 * 1 + 0);
@@ -90,8 +89,8 @@ void iree_uk_mmt4d_tile_i8i8i32_8x8x8_arm_64_i8mm(
     acc_67_45 = vdupq_n_s32(0);
     acc_67_67 = vdupq_n_s32(0);
   }
-  IREE_UK_ASSUME(K >= 1);
-  for (int k = 0; k < K; ++k) {
+  IREE_UK_ASSUME(params->K >= 1);
+  for (int k = 0; k < params->K; ++k) {
     int8x16_t lhs01 = vld1q_s8(lhs_ptr + 0);
     int8x16_t lhs23 = vld1q_s8(lhs_ptr + 16);
     int8x16_t lhs45 = vld1q_s8(lhs_ptr + 32);

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx2_fma.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx2_fma.c
@@ -9,13 +9,13 @@
 
 void iree_uk_mmt4d_tile_f32f32f32_8x8x1_x86_64_avx2_fma(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   float* IREE_UK_RESTRICT out_ptr = out_tile;
   const float* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const float* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
   __m256 acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7;
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     acc0 = _mm256_loadu_ps(out_ptr + 0 * 8);
     acc1 = _mm256_loadu_ps(out_ptr + 1 * 8);
     acc2 = _mm256_loadu_ps(out_ptr + 2 * 8);
@@ -34,7 +34,7 @@ void iree_uk_mmt4d_tile_f32f32f32_8x8x1_x86_64_avx2_fma(
     acc6 = _mm256_setzero_ps();
     acc7 = _mm256_setzero_ps();
   }
-  for (iree_uk_int32_t k = 0; k < K; ++k) {
+  for (iree_uk_int32_t k = 0; k < params->K; ++k) {
     __m256 rhs = _mm256_loadu_ps(rhs_ptr);
     rhs_ptr += 8;
     acc0 = _mm256_fmadd_ps(_mm256_broadcast_ss(lhs_ptr + 0), rhs, acc0);
@@ -62,13 +62,12 @@ void iree_uk_mmt4d_tile_f32f32f32_8x8x1_x86_64_avx2_fma(
 // should only be used if IREE_UK_FLAG_MMT4D_SKIP_INTERMEDIATE_ROUNDINGS is set.
 static void iree_uk_mmt4d_tile_f16f16fXX_8x8x1_x86_64_avx2_fma(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params,
-    iree_uk_type_t acc_type) {
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params, iree_uk_type_t acc_type) {
   const iree_uk_uint16_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const iree_uk_uint16_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
   __m256 acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7;
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     if (acc_type == IREE_UK_TYPE_FLOAT_32) {
       float* IREE_UK_RESTRICT out_ptr = out_tile;
       acc0 = _mm256_loadu_ps(out_ptr + 0 * 8);
@@ -108,7 +107,7 @@ static void iree_uk_mmt4d_tile_f16f16fXX_8x8x1_x86_64_avx2_fma(
     acc6 = _mm256_setzero_ps();
     acc7 = _mm256_setzero_ps();
   }
-  for (iree_uk_int32_t k = 0; k < K; ++k) {
+  for (iree_uk_int32_t k = 0; k < params->K; ++k) {
     __m256 rhs = _mm256_cvtph_ps(_mm_loadu_si128((const __m128i*)rhs_ptr));
     rhs_ptr += 8;
     acc0 =
@@ -162,24 +161,24 @@ static void iree_uk_mmt4d_tile_f16f16fXX_8x8x1_x86_64_avx2_fma(
 
 void iree_uk_mmt4d_tile_f16f16f16_8x8x1_x86_64_avx2_fma(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   iree_uk_mmt4d_tile_f16f16fXX_8x8x1_x86_64_avx2_fma(
-      out_tile, lhs_panel, rhs_panel, K, flags, params, IREE_UK_TYPE_FLOAT_16);
+      out_tile, lhs_panel, rhs_panel, params, IREE_UK_TYPE_FLOAT_16);
 }
 
 void iree_uk_mmt4d_tile_f16f16f32_8x8x1_x86_64_avx2_fma(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   iree_uk_mmt4d_tile_f16f16fXX_8x8x1_x86_64_avx2_fma(
-      out_tile, lhs_panel, rhs_panel, K, flags, params, IREE_UK_TYPE_FLOAT_32);
+      out_tile, lhs_panel, rhs_panel, params, IREE_UK_TYPE_FLOAT_32);
 }
 
 void iree_uk_mmt4d_tile_i8i8i32_8x8x2_x86_64_avx2_fma(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   iree_uk_int32_t* IREE_UK_RESTRICT out_ptr = out_tile;
   const iree_uk_int8_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const iree_uk_int8_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
@@ -192,7 +191,7 @@ void iree_uk_mmt4d_tile_i8i8i32_8x8x2_x86_64_avx2_fma(
   __m256i acc_3_0123_7_4567;
   __m256i acc_3_4567_7_0123;
 
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     acc_0_0123_4_4567 = iree_uk_avx_loadu_2x128(
         (__m128i*)(out_ptr + 0 * 8 + 0), (__m128i*)(out_ptr + 4 * 8 + 4));
     acc_0_4567_4_0123 = iree_uk_avx_loadu_2x128(
@@ -219,7 +218,7 @@ void iree_uk_mmt4d_tile_i8i8i32_8x8x2_x86_64_avx2_fma(
     acc_3_0123_7_4567 = _mm256_setzero_si256();
     acc_3_4567_7_0123 = _mm256_setzero_si256();
   }
-  for (iree_uk_int32_t k = 0; k < K; ++k) {
+  for (iree_uk_int32_t k = 0; k < params->K; ++k) {
     __m256i rhs_i16_01234567 =
         _mm256_cvtepi8_epi16(_mm_loadu_si128((const __m128i*)rhs_ptr));
     rhs_ptr += 16;

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_base.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_base.c
@@ -9,8 +9,8 @@
 
 void iree_uk_mmt4d_tile_f32f32f32_16x16x1_x86_64_avx512_base(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   float* IREE_UK_RESTRICT out_ptr = out_tile;
   const float* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const float* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
@@ -23,7 +23,7 @@ void iree_uk_mmt4d_tile_f32f32f32_16x16x1_x86_64_avx512_base(
   _mm_prefetch((const char*)rhs_ptr, _MM_HINT_T0);
   __m512 acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7;
   __m512 acc8, acc9, acc10, acc11, acc12, acc13, acc14, acc15;
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     acc0 = _mm512_loadu_ps(out_ptr + 0 * 16);
     acc1 = _mm512_loadu_ps(out_ptr + 1 * 16);
     acc2 = _mm512_loadu_ps(out_ptr + 2 * 16);
@@ -58,7 +58,7 @@ void iree_uk_mmt4d_tile_f32f32f32_16x16x1_x86_64_avx512_base(
     acc14 = _mm512_setzero_ps();
     acc15 = _mm512_setzero_ps();
   }
-  for (iree_uk_int32_t k = 0; k < K; ++k) {
+  for (iree_uk_int32_t k = 0; k < params->K; ++k) {
     __m512 rhs = _mm512_loadu_ps(rhs_ptr);
     _mm_prefetch((const char*)(rhs_ptr + 128), _MM_HINT_T0);
     rhs_ptr += 16;
@@ -104,9 +104,8 @@ void iree_uk_mmt4d_tile_f32f32f32_16x16x1_x86_64_avx512_base(
 // should only be used if IREE_UK_FLAG_MMT4D_SKIP_INTERMEDIATE_ROUNDINGS is set.
 static void iree_uk_mmt4d_tile_f16f16fXX_16x16x1_x86_64_avx512_base(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params,
-    iree_uk_type_t acc_type) {
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params, iree_uk_type_t acc_type) {
   const iree_uk_uint16_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const iree_uk_uint16_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
   // The prefetches in this function are carried over from
@@ -115,7 +114,7 @@ static void iree_uk_mmt4d_tile_f16f16fXX_16x16x1_x86_64_avx512_base(
   _mm_prefetch((const char*)rhs_ptr, _MM_HINT_T0);
   __m512 acc0, acc1, acc2, acc3, acc4, acc5, acc6, acc7;
   __m512 acc8, acc9, acc10, acc11, acc12, acc13, acc14, acc15;
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     if (acc_type == IREE_UK_TYPE_FLOAT_32) {
       float* IREE_UK_RESTRICT out_ptr = out_tile;
       acc0 = _mm512_loadu_ps(out_ptr + 0 * 16);
@@ -187,7 +186,7 @@ static void iree_uk_mmt4d_tile_f16f16fXX_16x16x1_x86_64_avx512_base(
     acc14 = _mm512_setzero_ps();
     acc15 = _mm512_setzero_ps();
   }
-  for (iree_uk_int32_t k = 0; k < K; ++k) {
+  for (iree_uk_int32_t k = 0; k < params->K; ++k) {
     __m512 rhs = _mm512_cvtph_ps(_mm256_loadu_si256((const __m256i*)rhs_ptr));
     _mm_prefetch((const char*)(rhs_ptr + 128), _MM_HINT_T0);
     rhs_ptr += 16;
@@ -283,24 +282,24 @@ static void iree_uk_mmt4d_tile_f16f16fXX_16x16x1_x86_64_avx512_base(
 
 void iree_uk_mmt4d_tile_f16f16f16_16x16x1_x86_64_avx512_base(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   iree_uk_mmt4d_tile_f16f16fXX_16x16x1_x86_64_avx512_base(
-      out_tile, lhs_panel, rhs_panel, K, flags, params, IREE_UK_TYPE_FLOAT_16);
+      out_tile, lhs_panel, rhs_panel, params, IREE_UK_TYPE_FLOAT_16);
 }
 
 void iree_uk_mmt4d_tile_f16f16f32_16x16x1_x86_64_avx512_base(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   iree_uk_mmt4d_tile_f16f16fXX_16x16x1_x86_64_avx512_base(
-      out_tile, lhs_panel, rhs_panel, K, flags, params, IREE_UK_TYPE_FLOAT_32);
+      out_tile, lhs_panel, rhs_panel, params, IREE_UK_TYPE_FLOAT_32);
 }
 
 void iree_uk_mmt4d_tile_i8i8i32_16x16x2_x86_64_avx512_base(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   iree_uk_int32_t* IREE_UK_RESTRICT out_ptr = out_tile;
   const iree_uk_int8_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const iree_uk_int8_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
@@ -322,7 +321,7 @@ void iree_uk_mmt4d_tile_i8i8i32_16x16x2_x86_64_avx512_base(
   __m512i acc_3_89AB_7_CDEF_B_0123_F_4567;
   __m512i acc_3_CDEF_7_89AB_B_4567_F_0123;
 
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     acc_0_0123_4_4567_8_89AB_C_CDEF = iree_uk_avx512_loadu_4x128_from_16x16xi32(
         out_ptr, 0, 0, 4, 4, 8, 8, 12, 12);
     acc_0_4567_4_0123_8_CDEF_C_89AB = iree_uk_avx512_loadu_4x128_from_16x16xi32(
@@ -381,7 +380,7 @@ void iree_uk_mmt4d_tile_i8i8i32_16x16x2_x86_64_avx512_base(
   __m512i idx_CDEF89AB45670123 =
       _mm512_setr_epi32(12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3);
 
-  for (iree_uk_int32_t k = 0; k < K; ++k) {
+  for (iree_uk_int32_t k = 0; k < params->K; ++k) {
     __m512i rhs_i16_0123456789ABCDEF =
         _mm512_cvtepi8_epi16(_mm256_loadu_si256((const __m256i*)rhs_ptr));
     rhs_ptr += 32;

--- a/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_vnni.c
+++ b/runtime/src/iree/builtins/ukernel/arch/x86_64/mmt4d_x86_64_avx512_vnni.c
@@ -9,8 +9,8 @@
 
 void iree_uk_mmt4d_tile_i8i8i32_16x16x2_x86_64_avx512_vnni(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params) {
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params) {
   iree_uk_int32_t* IREE_UK_RESTRICT out_ptr = out_tile;
   const iree_uk_int8_t* IREE_UK_RESTRICT lhs_ptr = lhs_panel;
   const iree_uk_int8_t* IREE_UK_RESTRICT rhs_ptr = rhs_panel;
@@ -32,7 +32,7 @@ void iree_uk_mmt4d_tile_i8i8i32_16x16x2_x86_64_avx512_vnni(
   __m512i acc_3_89AB_7_CDEF_B_0123_F_4567;
   __m512i acc_3_CDEF_7_89AB_B_4567_F_0123;
 
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     acc_0_0123_4_4567_8_89AB_C_CDEF = iree_uk_avx512_loadu_4x128_from_16x16xi32(
         out_ptr, 0, 0, 4, 4, 8, 8, 12, 12);
     acc_0_4567_4_0123_8_CDEF_C_89AB = iree_uk_avx512_loadu_4x128_from_16x16xi32(
@@ -91,7 +91,7 @@ void iree_uk_mmt4d_tile_i8i8i32_16x16x2_x86_64_avx512_vnni(
   __m512i idx_CDEF89AB45670123 =
       _mm512_setr_epi32(12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3);
 
-  for (iree_uk_int32_t k = 0; k < K; ++k) {
+  for (iree_uk_int32_t k = 0; k < params->K; ++k) {
     __m512i rhs_i16_0123456789ABCDEF =
         _mm512_cvtepi8_epi16(_mm256_loadu_si256((const __m256i*)rhs_ptr));
     rhs_ptr += 32;

--- a/runtime/src/iree/builtins/ukernel/mmt4d.c
+++ b/runtime/src/iree/builtins/ukernel/mmt4d.c
@@ -50,7 +50,6 @@ static void iree_uk_mmt4d_using_tile_func(const iree_uk_mmt4d_params_t* params,
                                           iree_uk_mmt4d_tile_func_t tile_func) {
   const iree_uk_int32_t M = params->M;
   const iree_uk_int32_t N = params->N;
-  const iree_uk_int32_t K = params->K;
   const iree_uk_int16_t M0 = params->M0;
   const iree_uk_int16_t N0 = params->N0;
   iree_uk_mmt4d_type_t mmt4d_type = iree_uk_mmt4d_type(params->flags);
@@ -78,7 +77,7 @@ static void iree_uk_mmt4d_using_tile_func(const iree_uk_mmt4d_params_t* params,
     IREE_UK_PREFETCH_RO(lhs_panel, IREE_UK_PREFETCH_LOCALITY_L1);
     IREE_UK_PREFETCH_RO(rhs_panel, IREE_UK_PREFETCH_LOCALITY_L1);
     for (iree_uk_int32_t j = 0; j < N; ++j) {
-      tile_func(out_tile, lhs_panel, rhs_panel, K, params->flags, params);
+      tile_func(out_tile, lhs_panel, rhs_panel, params);
       out_tile += out_tile_size;
       rhs_panel += rhs_panel_stride;
     }

--- a/runtime/src/iree/builtins/ukernel/mmt4d_internal.h
+++ b/runtime/src/iree/builtins/ukernel/mmt4d_internal.h
@@ -69,24 +69,17 @@ static inline iree_uk_type_t iree_uk_mmt4d_out_type(iree_uk_mmt4d_type_t type) {
 // the inner-most loop of the matmul, i.e. the thing that we should actually
 // be calling "micro kernel" except that the name is already taken by the
 // higher-level builtin name.
-//
-// The 'params' argument is only used by generic kernels. Actual optimized
-// kernels are already specialized for a given tile shape (M0xN0xK0), so the
-// five first arguments here are the only information that they need. Not having
-// to address 'params' struct fields in the middle of assembly kernels is
-// good, because it's hard to get the struct field offsets right in assembly
-// and keep that in sync with future struct changes.
 typedef void (*iree_uk_mmt4d_tile_func_t)(
     void* IREE_UK_RESTRICT out_tile, const void* IREE_UK_RESTRICT lhs_panel,
-    const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K,
-    iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params);
+    const void* IREE_UK_RESTRICT rhs_panel,
+    const iree_uk_mmt4d_params_t* params);
 
 // Tile kernel declarations. Prototype matches iree_uk_mmt4d_tile_func_t.
-#define IREE_UK_MMT4D_TILE_FUNC_DECL(NAME)                             \
-  void NAME(void* IREE_UK_RESTRICT out_tile,                           \
-            const void* IREE_UK_RESTRICT lhs_panel,                    \
-            const void* IREE_UK_RESTRICT rhs_panel, iree_uk_int32_t K, \
-            iree_uk_uint32_t flags, const iree_uk_mmt4d_params_t* params);
+#define IREE_UK_MMT4D_TILE_FUNC_DECL(NAME)          \
+  void NAME(void* IREE_UK_RESTRICT out_tile,        \
+            const void* IREE_UK_RESTRICT lhs_panel, \
+            const void* IREE_UK_RESTRICT rhs_panel, \
+            const iree_uk_mmt4d_params_t* params);
 
 // In order to be helpful as a reference for future architecture-specific
 // kernels, the generic kernels are structured like an actual optimized kernel,

--- a/runtime/src/iree/builtins/ukernel/mmt4d_tile.c
+++ b/runtime/src/iree/builtins/ukernel/mmt4d_tile.c
@@ -9,8 +9,7 @@
 // Generic implementation of matmul tile, i8*i8->i32 case.
 static void iree_uk_mmt4d_tile_i8i8i32_generic(
     void* out_tile_untyped, const void* lhs_panel_untyped,
-    const void* rhs_panel_untyped, iree_uk_int32_t K, iree_uk_uint32_t flags,
-    const iree_uk_mmt4d_params_t* params) {
+    const void* rhs_panel_untyped, const iree_uk_mmt4d_params_t* params) {
   iree_uk_int32_t* out_tile = out_tile_untyped;
   const iree_uk_int8_t* lhs_panel = lhs_panel_untyped;
   const iree_uk_int8_t* rhs_panel = rhs_panel_untyped;
@@ -19,13 +18,13 @@ static void iree_uk_mmt4d_tile_i8i8i32_generic(
   iree_uk_int16_t K0 = params->K0;
   // Initialize the local accumulator tile.
   iree_uk_int32_t acc[iree_uk_mmt4d_tile_generic_max_bytes / sizeof(*out_tile)];
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     for (int i = 0; i < M0 * N0; ++i) acc[i] = out_tile[i];
   } else {
     for (int i = 0; i < M0 * N0; ++i) acc[i] = 0;
   }
   // Accumulation loop.
-  for (iree_uk_index_t k = 0; k < K; ++k) {
+  for (iree_uk_index_t k = 0; k < params->K; ++k) {
     for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
       for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
         for (iree_uk_index_t k0 = 0; k0 < K0; ++k0) {
@@ -45,8 +44,7 @@ static void iree_uk_mmt4d_tile_i8i8i32_generic(
 // Generic implementation of matmul tile, f32*f32->f32 case.
 static void iree_uk_mmt4d_tile_f32f32f32_generic(
     void* out_tile_untyped, const void* lhs_panel_untyped,
-    const void* rhs_panel_untyped, iree_uk_int32_t K, iree_uk_uint32_t flags,
-    const iree_uk_mmt4d_params_t* params) {
+    const void* rhs_panel_untyped, const iree_uk_mmt4d_params_t* params) {
   float* out_tile = out_tile_untyped;
   const float* lhs_panel = lhs_panel_untyped;
   const float* rhs_panel = rhs_panel_untyped;
@@ -55,13 +53,13 @@ static void iree_uk_mmt4d_tile_f32f32f32_generic(
   iree_uk_int16_t K0 = params->K0;
   // Initialize the local accumulator tile.
   float acc[iree_uk_mmt4d_tile_generic_max_bytes / sizeof(*out_tile)];
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     for (int i = 0; i < M0 * N0; ++i) acc[i] = out_tile[i];
   } else {
     for (int i = 0; i < M0 * N0; ++i) acc[i] = 0;
   }
   // Accumulation loop.
-  for (iree_uk_index_t k = 0; k < K; ++k) {
+  for (iree_uk_index_t k = 0; k < params->K; ++k) {
     for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
       for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
         for (iree_uk_index_t k0 = 0; k0 < K0; ++k0) {
@@ -81,8 +79,7 @@ static void iree_uk_mmt4d_tile_f32f32f32_generic(
 // Generic implementation of matmul tile, f16*f16->f32 case.
 static void iree_uk_mmt4d_tile_f16f16f32_generic(
     void* out_tile_untyped, const void* lhs_panel_untyped,
-    const void* rhs_panel_untyped, iree_uk_int32_t K, iree_uk_uint32_t flags,
-    const iree_uk_mmt4d_params_t* params) {
+    const void* rhs_panel_untyped, const iree_uk_mmt4d_params_t* params) {
   float* out_tile = out_tile_untyped;
   const iree_uk_uint16_t* lhs_panel = lhs_panel_untyped;
   const iree_uk_uint16_t* rhs_panel = rhs_panel_untyped;
@@ -91,13 +88,13 @@ static void iree_uk_mmt4d_tile_f16f16f32_generic(
   iree_uk_int16_t K0 = params->K0;
   // Initialize the local accumulator tile.
   float acc[iree_uk_mmt4d_tile_generic_max_bytes / sizeof(*out_tile)];
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     for (int i = 0; i < M0 * N0; ++i) acc[i] = out_tile[i];
   } else {
     for (int i = 0; i < M0 * N0; ++i) acc[i] = 0;
   }
   // Accumulation loop.
-  for (iree_uk_index_t k = 0; k < K; ++k) {
+  for (iree_uk_index_t k = 0; k < params->K; ++k) {
     for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
       for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
         for (iree_uk_index_t k0 = 0; k0 < K0; ++k0) {
@@ -117,8 +114,7 @@ static void iree_uk_mmt4d_tile_f16f16f32_generic(
 // Generic implementation of matmul tile, f16*f16->f16 case.
 static void iree_uk_mmt4d_tile_f16f16f16_generic(
     void* out_tile_untyped, const void* lhs_panel_untyped,
-    const void* rhs_panel_untyped, iree_uk_int32_t K, iree_uk_uint32_t flags,
-    const iree_uk_mmt4d_params_t* params) {
+    const void* rhs_panel_untyped, const iree_uk_mmt4d_params_t* params) {
   iree_uk_int16_t* out_tile = out_tile_untyped;
   const iree_uk_uint16_t* lhs_panel = lhs_panel_untyped;
   const iree_uk_uint16_t* rhs_panel = rhs_panel_untyped;
@@ -127,13 +123,13 @@ static void iree_uk_mmt4d_tile_f16f16f16_generic(
   iree_uk_int16_t K0 = params->K0;
   // Initialize the local accumulator tile.
   iree_uk_int16_t acc[iree_uk_mmt4d_tile_generic_max_bytes / sizeof(*out_tile)];
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     for (int i = 0; i < M0 * N0; ++i) acc[i] = out_tile[i];
   } else {
     for (int i = 0; i < M0 * N0; ++i) acc[i] = 0;
   }
   // Accumulation loop.
-  for (iree_uk_index_t k = 0; k < K; ++k) {
+  for (iree_uk_index_t k = 0; k < params->K; ++k) {
     for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
       for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
         for (iree_uk_index_t k0 = 0; k0 < K0; ++k0) {
@@ -155,8 +151,7 @@ static void iree_uk_mmt4d_tile_f16f16f16_generic(
 // Generic implementation of matmul tile, bf16*bf16->f32 case.
 static void iree_uk_mmt4d_tile_bf16bf16f32_generic(
     void* out_tile_untyped, const void* lhs_panel_untyped,
-    const void* rhs_panel_untyped, iree_uk_int32_t K, iree_uk_uint32_t flags,
-    const iree_uk_mmt4d_params_t* params) {
+    const void* rhs_panel_untyped, const iree_uk_mmt4d_params_t* params) {
   float* out_tile = out_tile_untyped;
   const iree_uk_uint16_t* lhs_panel = lhs_panel_untyped;
   const iree_uk_uint16_t* rhs_panel = rhs_panel_untyped;
@@ -165,13 +160,13 @@ static void iree_uk_mmt4d_tile_bf16bf16f32_generic(
   iree_uk_int16_t K0 = params->K0;
   // Initialize the local accumulator tile.
   float acc[iree_uk_mmt4d_tile_generic_max_bytes / sizeof(*out_tile)];
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     for (int i = 0; i < M0 * N0; ++i) acc[i] = out_tile[i];
   } else {
     for (int i = 0; i < M0 * N0; ++i) acc[i] = 0;
   }
   // Accumulation loop.
-  for (iree_uk_index_t k = 0; k < K; ++k) {
+  for (iree_uk_index_t k = 0; k < params->K; ++k) {
     for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
       for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
         for (iree_uk_index_t k0 = 0; k0 < K0; ++k0) {
@@ -191,8 +186,7 @@ static void iree_uk_mmt4d_tile_bf16bf16f32_generic(
 // Generic implementation of matmul tile, bf16*bf16->bf16 case.
 static void iree_uk_mmt4d_tile_bf16bf16bf16_generic(
     void* out_tile_untyped, const void* lhs_panel_untyped,
-    const void* rhs_panel_untyped, iree_uk_int32_t K, iree_uk_uint32_t flags,
-    const iree_uk_mmt4d_params_t* params) {
+    const void* rhs_panel_untyped, const iree_uk_mmt4d_params_t* params) {
   iree_uk_int16_t* out_tile = out_tile_untyped;
   const iree_uk_uint16_t* lhs_panel = lhs_panel_untyped;
   const iree_uk_uint16_t* rhs_panel = rhs_panel_untyped;
@@ -201,13 +195,13 @@ static void iree_uk_mmt4d_tile_bf16bf16bf16_generic(
   iree_uk_int16_t K0 = params->K0;
   // Initialize the local accumulator tile.
   iree_uk_int16_t acc[iree_uk_mmt4d_tile_generic_max_bytes / sizeof(*out_tile)];
-  if (flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
+  if (params->flags & IREE_UK_FLAG_MMT4D_ACCUMULATE) {
     for (int i = 0; i < M0 * N0; ++i) acc[i] = out_tile[i];
   } else {
     for (int i = 0; i < M0 * N0; ++i) acc[i] = 0;
   }
   // Accumulation loop.
-  for (iree_uk_index_t k = 0; k < K; ++k) {
+  for (iree_uk_index_t k = 0; k < params->K; ++k) {
     for (iree_uk_index_t i0 = 0; i0 < M0; ++i0) {
       for (iree_uk_index_t j0 = 0; j0 < N0; ++j0) {
         for (iree_uk_index_t k0 = 0; k0 < K0; ++k0) {


### PR DESCRIPTION
This simply brings matmul tile calculation for AArch64 SVE more in line with X86 and RISC-V. This change is not driven by any performance considerations just yet. However, it helps with development, i.e. SVE and scalable vectorisation bring-up.

More specifically, the matmul tile sizes resulting from current set-up ([20, 4, 64]) mixed with vectorisation via vector.contract lead to very expansive unrolling during `LVMCPUVectorLowering`. The new set-up effectively prevents that.

This changes should not affect current AArch64 testing/performance as that's targeting NEON and these changes will only affect compilations with SVE enabled.